### PR TITLE
feat: 调整设置窗口和菜单内容视图的尺寸

### DIFF
--- a/Sources/AIPlanMonitor/App/SettingsWindowController.swift
+++ b/Sources/AIPlanMonitor/App/SettingsWindowController.swift
@@ -13,7 +13,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     }
 
     func show(viewModel: AppViewModel) {
-        let targetContentSize = NSSize(width: 960, height: 671)
+        let targetContentSize = NSSize(width: 960, height: 670)
         if window == nil {
             // 窗口基础尺寸：对应设置页整体画布宽高（与 Figma 画板尺寸对齐）。
             let panel = NSWindow(
@@ -48,7 +48,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
             panel.isMovableByWindowBackground = true
             panel.isReleasedWhenClosed = false
             panel.delegate = self
-            // 固定“内容区”为 960x671（min/max 需使用 frameRect 尺寸）。
+            // 固定“内容区”为 960x670（min/max 需使用 frameRect 尺寸）。
             let fixedFrameSize = panel.frameRect(
                 forContentRect: NSRect(origin: .zero, size: targetContentSize)
             ).size

--- a/Sources/AIPlanMonitor/App/SettingsWindowController.swift
+++ b/Sources/AIPlanMonitor/App/SettingsWindowController.swift
@@ -13,7 +13,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     }
 
     func show(viewModel: AppViewModel) {
-        let targetContentSize = NSSize(width: 800, height: 671)
+        let targetContentSize = NSSize(width: 960, height: 671)
         if window == nil {
             // 窗口基础尺寸：对应设置页整体画布宽高（与 Figma 画板尺寸对齐）。
             let panel = NSWindow(
@@ -48,7 +48,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
             panel.isMovableByWindowBackground = true
             panel.isReleasedWhenClosed = false
             panel.delegate = self
-            // 固定“内容区”为 800x671（min/max 需使用 frameRect 尺寸）。
+            // 固定“内容区”为 960x671（min/max 需使用 frameRect 尺寸）。
             let fixedFrameSize = panel.frameRect(
                 forContentRect: NSRect(origin: .zero, size: targetContentSize)
             ).size

--- a/Sources/AIPlanMonitor/UI/MenuContentView.swift
+++ b/Sources/AIPlanMonitor/UI/MenuContentView.swift
@@ -47,7 +47,7 @@ struct MenuContentView: View {
             header
             cards
         }
-        .frame(width: 363)
+        .frame(width: 360)
         .padding(.top, 14)
         .padding(.bottom, 8)
         .padding(.horizontal, 8)

--- a/Sources/AIPlanMonitor/UI/MenuContentView.swift
+++ b/Sources/AIPlanMonitor/UI/MenuContentView.swift
@@ -47,7 +47,7 @@ struct MenuContentView: View {
             header
             cards
         }
-        .frame(width: 316)
+        .frame(width: 363)
         .padding(.top, 14)
         .padding(.bottom, 8)
         .padding(.horizontal, 8)

--- a/Sources/AIPlanMonitor/UI/SettingsView.swift
+++ b/Sources/AIPlanMonitor/UI/SettingsView.swift
@@ -7167,7 +7167,7 @@ struct SettingsView: View {
         vm.setLanguage(.zhHans)
         return vm
     }())
-    .frame(width: 960, height: 671)
+    .frame(width: 960, height: 670)
     .preferredColorScheme(.dark)
 }
 

--- a/Sources/AIPlanMonitor/UI/SettingsView.swift
+++ b/Sources/AIPlanMonitor/UI/SettingsView.swift
@@ -7167,7 +7167,7 @@ struct SettingsView: View {
         vm.setLanguage(.zhHans)
         return vm
     }())
-    .frame(width: 800, height: 671)
+    .frame(width: 960, height: 671)
     .preferredColorScheme(.dark)
 }
 


### PR DESCRIPTION
更新设置窗口和菜单内容视图的宽度，以提供更好的用户体验。
- 设置窗口宽度从800调整为960
- 菜单内容视图宽度从316调整为363