### PR TITLE
feat: 添加对 Codex 和 Claude 个人资料的备注支持

### DIFF
--- a/Sources/AIPlanMonitor/App/AppViewModel.swift
+++ b/Sources/AIPlanMonitor/App/AppViewModel.swift
@@ -848,6 +848,7 @@ final class AppViewModel {
                     isActive: slot.isActive,
                     lastSeenAt: slot.lastSeenAt,
                     displayName: profile?.displayName ?? slot.displayName,
+                    note: profile?.note,
                     isSwitching: codexSwitchingSlots.contains(slot.slotID),
                     canSwitch: profile != nil && !(profile?.isCurrentSystemAccount ?? false),
                     isCurrentSystemAccount: profile?.isCurrentSystemAccount ?? false,
@@ -871,11 +872,12 @@ final class AppViewModel {
         "Codex \(slotID.rawValue)"
     }
 
-    func saveCodexProfile(slotID: CodexSlotID, displayName: String, authJSON: String) -> String {
+    func saveCodexProfile(slotID: CodexSlotID, displayName: String, note: String?, authJSON: String) -> String {
         do {
             _ = try codexProfileStore.saveProfile(
                 slotID: slotID,
                 displayName: displayName,
+                note: note,
                 authJSON: authJSON,
                 currentFingerprint: codexDesktopAuthService.currentCredentialFingerprint()
             )
@@ -921,6 +923,7 @@ final class AppViewModel {
                     isActive: slot.isActive,
                     lastSeenAt: slot.lastSeenAt,
                     displayName: profile?.displayName ?? slot.displayName,
+                    note: profile?.note,
                     source: profile?.source,
                     isSwitching: claudeSwitchingSlots.contains(slot.slotID),
                     canSwitch: profile != nil && !(profile?.isCurrentSystemAccount ?? false),
@@ -948,6 +951,7 @@ final class AppViewModel {
     func saveClaudeProfile(
         slotID: CodexSlotID,
         displayName: String,
+        note: String?,
         source: ClaudeProfileSource,
         configDir: String?,
         credentialsJSON: String?
@@ -956,6 +960,7 @@ final class AppViewModel {
             _ = try claudeProfileStore.saveProfile(
                 slotID: slotID,
                 displayName: displayName,
+                note: note,
                 source: source,
                 configDir: configDir,
                 credentialsJSON: credentialsJSON,

--- a/Sources/AIPlanMonitor/Models/ProviderModels.swift
+++ b/Sources/AIPlanMonitor/Models/ProviderModels.swift
@@ -422,6 +422,7 @@ struct CodexSlotViewModel: Identifiable, Equatable {
     var isActive: Bool
     var lastSeenAt: Date
     var displayName: String
+    var note: String?
     var isSwitching: Bool = false
     var canSwitch: Bool = false
     var isCurrentSystemAccount: Bool = false
@@ -434,6 +435,7 @@ struct CodexAccountProfile: Codable, Equatable, Identifiable {
     var id: String { slotID.rawValue }
     var slotID: CodexSlotID
     var displayName: String
+    var note: String?
     var authJSON: String
     var accountId: String?
     var accountEmail: String?
@@ -465,6 +467,7 @@ struct ClaudeSlotViewModel: Identifiable, Equatable {
     var isActive: Bool
     var lastSeenAt: Date
     var displayName: String
+    var note: String?
     var source: ClaudeProfileSource?
     var isSwitching: Bool = false
     var canSwitch: Bool = false
@@ -478,6 +481,7 @@ struct ClaudeAccountProfile: Codable, Equatable, Identifiable {
     var id: String { slotID.rawValue }
     var slotID: CodexSlotID
     var displayName: String
+    var note: String?
     var source: ClaudeProfileSource
     var configDir: String?
     var credentialsJSON: String?

--- a/Sources/AIPlanMonitor/Services/ClaudeAccountProfileStore.swift
+++ b/Sources/AIPlanMonitor/Services/ClaudeAccountProfileStore.swift
@@ -78,6 +78,7 @@ final class ClaudeAccountProfileStore {
     func saveProfile(
         slotID: CodexSlotID,
         displayName: String,
+        note: String?,
         source: ClaudeProfileSource,
         configDir: String?,
         credentialsJSON: String?,
@@ -98,6 +99,7 @@ final class ClaudeAccountProfileStore {
         var profile = ClaudeAccountProfile(
             slotID: slotID,
             displayName: Self.fallbackDisplayName(displayName, slotID: slotID),
+            note: Self.normalizedNote(note),
             source: source,
             configDir: resolvedConfigDir,
             credentialsJSON: source == .manualCredentials ? resolvedCredentialsJSON : resolvedCredentialsJSON,
@@ -322,6 +324,7 @@ final class ClaudeAccountProfileStore {
             ClaudeAccountProfile(
                 slotID: slotID,
                 displayName: "Claude \(slotID.rawValue)",
+                note: nil,
                 source: .configDir,
                 configDir: normalizedConfigDir,
                 credentialsJSON: trimmed,
@@ -526,6 +529,13 @@ final class ClaudeAccountProfileStore {
         return trimmed.isEmpty ? "Claude \(slotID.rawValue)" : trimmed
     }
 
+    private static func normalizedNote(_ note: String?) -> String? {
+        guard let trimmed = note?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
     private static func normalizedFingerprint(_ value: String?) -> String? {
         guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines),
               !value.isEmpty else {
@@ -695,6 +705,7 @@ final class ClaudeAccountProfileStore {
         var updated = profile
         updated.configDir = Self.normalizedConfigDirectory(updated.configDir)
         updated.displayName = Self.fallbackDisplayName(updated.displayName, slotID: updated.slotID)
+        updated.note = Self.normalizedNote(updated.note)
         if let credentialsJSON = updated.credentialsJSON?.trimmingCharacters(in: .whitespacesAndNewlines),
            !credentialsJSON.isEmpty,
            let payload = try? Self.parseCredentialsJSON(credentialsJSON) {

--- a/Sources/AIPlanMonitor/Services/CodexAccountProfileStore.swift
+++ b/Sources/AIPlanMonitor/Services/CodexAccountProfileStore.swift
@@ -72,12 +72,13 @@ final class CodexAccountProfileStore {
     func saveProfile(
         slotID: CodexSlotID,
         displayName: String,
+        note: String?,
         authJSON: String,
         currentFingerprint: String?
     ) throws -> CodexAccountProfile {
         var items = load()
         let payload = try Self.parseAuthJSON(authJSON)
-        var profile = try Self.makeProfile(slotID: slotID, displayName: displayName, authJSON: authJSON)
+        var profile = try Self.makeProfile(slotID: slotID, displayName: displayName, note: note, authJSON: authJSON)
         profile.isCurrentSystemAccount = profile.credentialFingerprint == currentFingerprint
         profile = normalizedProfile(profile, payload: payload)
         var ignoredFingerprints = loadIgnoredFingerprints()
@@ -190,6 +191,7 @@ final class CodexAccountProfileStore {
             CodexAccountProfile(
                 slotID: slotID,
                 displayName: "Codex \(slotID.rawValue)",
+                note: nil,
                 authJSON: trimmed,
                 accountId: payload.accountId,
                 accountEmail: payload.accountEmail,
@@ -212,15 +214,18 @@ final class CodexAccountProfileStore {
     static func makeProfile(
         slotID: CodexSlotID,
         displayName: String,
+        note: String?,
         authJSON: String,
         importedAt: Date = Date()
     ) throws -> CodexAccountProfile {
         let payload = try parseAuthJSON(authJSON)
         let identity = CodexIdentity.from(payload: payload)
         let trimmedName = displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNote = note?.trimmingCharacters(in: .whitespacesAndNewlines)
         return CodexAccountProfile(
             slotID: slotID,
             displayName: trimmedName.isEmpty ? "Codex \(slotID.rawValue)" : trimmedName,
+            note: (trimmedNote?.isEmpty ?? true) ? nil : trimmedNote,
             authJSON: authJSON.trimmingCharacters(in: .whitespacesAndNewlines),
             accountId: payload.accountId,
             accountEmail: payload.accountEmail,
@@ -331,6 +336,7 @@ final class CodexAccountProfileStore {
     ) -> CodexAccountProfile {
         var updated = profile
         let parsedPayload = payload ?? (try? Self.parseAuthJSON(profile.authJSON))
+        updated.note = CodexIdentity.trimmed(updated.note)
 
         if CodexIdentity.trimmed(updated.accountId) == nil {
             updated.accountId = parsedPayload?.accountId

--- a/Sources/AIPlanMonitor/UI/MenuContentView.swift
+++ b/Sources/AIPlanMonitor/UI/MenuContentView.swift
@@ -453,6 +453,7 @@ struct MenuContentView: View {
             subtitle: officialAccountSubtitle(
                 providerType: provider.type,
                 snapshot: slot.snapshot,
+                note: slot.note,
                 codexTeamAliases: codexTeamAliases
             ),
             status: percentageStatus(metrics: visibleMetrics, snapshot: slot.snapshot, disconnected: false),
@@ -488,7 +489,11 @@ struct MenuContentView: View {
             planType: monitorPlanType(for: provider, snapshot: slot.snapshot),
             iconName: iconName(for: provider),
             iconFallback: fallbackIcon(for: provider),
-            subtitle: officialAccountSubtitle(providerType: provider.type, snapshot: slot.snapshot),
+            subtitle: officialAccountSubtitle(
+                providerType: provider.type,
+                snapshot: slot.snapshot,
+                note: slot.note
+            ),
             status: percentageStatus(metrics: visibleMetrics, snapshot: slot.snapshot, disconnected: false),
             metrics: buildPercentageMetricDisplays(
                 from: visibleMetrics,
@@ -515,22 +520,38 @@ struct MenuContentView: View {
     private func officialAccountSubtitle(
         providerType: ProviderType,
         snapshot: UsageSnapshot?,
+        note: String? = nil,
         codexTeamAliases: [String: String] = [:]
     ) -> String? {
-        guard viewModel.showOfficialAccountEmailInMenuBar else { return nil }
-        guard let value = snapshot?.accountLabel?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !value.isEmpty else {
-            return nil
-        }
+        let accountValue: String? = {
+            guard viewModel.showOfficialAccountEmailInMenuBar,
+                  let value = snapshot?.accountLabel?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !value.isEmpty else {
+                return nil
+            }
+            return value
+        }()
+        let accountText = joinedSubtitleParts([accountValue, note])
 
         guard providerType == .codex else {
-            return value
+            return accountText
         }
 
         guard let teamAlias = codexTeamAlias(for: snapshot, aliases: codexTeamAliases) else {
-            return value
+            return accountText
         }
-        return "\(value) · \(teamAlias)"
+        return joinedSubtitleParts([accountText, teamAlias])
+    }
+
+    private func joinedSubtitleParts(_ parts: [String?]) -> String? {
+        let values = parts.compactMap { raw -> String? in
+            guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+                return nil
+            }
+            return trimmed
+        }
+        guard !values.isEmpty else { return nil }
+        return values.joined(separator: " · ")
     }
 
     private func relaySecondaryText(provider: ProviderDescriptor, snapshot: UsageSnapshot?) -> String? {

--- a/Sources/AIPlanMonitor/UI/SettingsView.swift
+++ b/Sources/AIPlanMonitor/UI/SettingsView.swift
@@ -37,18 +37,22 @@ struct SettingsView: View {
     @State private var officialQuotaDisplayModeInputs: [String: OfficialQuotaDisplayMode] = [:]
     @State private var officialCookieInputs: [String: String] = [:]
     @State private var codexProfileJSONInputs: [String: String] = [:]
+    @State private var codexProfileNoteInputs: [String: String] = [:]
     @State private var codexProfileResult: [String: String] = [:]
     @State private var codexProfilePendingDelete: CodexSlotID?
     @State private var codexProfileEditor: CodexProfileEditorState?
     @State private var codexProfileEditorJSON = ""
+    @State private var codexProfileEditorNote = ""
     @State private var claudeProfileJSONInputs: [String: String] = [:]
     @State private var claudeProfileConfigDirInputs: [String: String] = [:]
+    @State private var claudeProfileNoteInputs: [String: String] = [:]
     @State private var claudeProfileResult: [String: String] = [:]
     @State private var claudeProfilePendingDelete: CodexSlotID?
     @State private var claudeProfileEditor: ClaudeProfileEditorState?
     @State private var claudeProfileEditorSource: ClaudeProfileSource = .configDir
     @State private var claudeProfileEditorConfigDir = ""
     @State private var claudeProfileEditorJSON = ""
+    @State private var claudeProfileEditorNote = ""
     @State private var permissionPrompt: PermissionPrompt?
     @State private var permissionResultMessage: [String: String] = [:]
     @State private var permissionResultIsError: [String: Bool] = [:]
@@ -4815,6 +4819,11 @@ struct SettingsView: View {
         let trailingInfo = viewModel.language == .zhHans
             ? "更新于 \(settingsElapsedText(from: updatedAt))"
             : "\(viewModel.text(.updatedAgo)) \(settingsElapsedText(from: updatedAt))"
+        let subtitle = profileEmailWithNote(
+            email: profile.accountEmail,
+            note: profile.note,
+            fallback: viewModel.text(.codexProfileEmailUnknown)
+        )
 
         return officialAccountMonitorCard(
             highlightColor: hasError ? Color(hex: 0xD05757) : nil
@@ -4828,7 +4837,7 @@ struct SettingsView: View {
                             title: "Codex \(profile.slotID.rawValue)",
                             planType: planType
                         )
-                        Text(profile.accountEmail ?? viewModel.text(.codexProfileEmailUnknown))
+                        Text(subtitle)
                             .font(.system(size: 10, weight: .regular))
                             .foregroundStyle(settingsHintColor)
                             .lineLimit(1)
@@ -5024,7 +5033,11 @@ struct SettingsView: View {
         let trailingInfo = viewModel.language == .zhHans
             ? "更新于 \(settingsElapsedText(from: updatedAt))"
             : "\(viewModel.text(.updatedAgo)) \(settingsElapsedText(from: updatedAt))"
-        let subtitle = profile.accountEmail ?? viewModel.localizedText("未识别账号", "Account unavailable")
+        let subtitle = profileEmailWithNote(
+            email: profile.accountEmail,
+            note: profile.note,
+            fallback: viewModel.localizedText("未识别账号", "Account unavailable")
+        )
 
         return officialAccountMonitorCard(
             highlightColor: hasError ? Color(hex: 0xD05757) : nil
@@ -5173,6 +5186,7 @@ struct SettingsView: View {
         claudeProfileEditorSource = existingProfile?.source ?? .configDir
         claudeProfileEditorConfigDir = claudeProfileConfigDirInputs[key] ?? existingProfile?.configDir ?? ""
         claudeProfileEditorJSON = claudeProfileJSONInputs[key] ?? existingProfile?.credentialsJSON ?? ""
+        claudeProfileEditorNote = claudeProfileNoteInputs[key] ?? existingProfile?.note ?? ""
         claudeProfileEditor = ClaudeProfileEditorState(
             slotID: slotID,
             title: viewModel.claudeSettingsTitle(for: slotID),
@@ -5185,9 +5199,11 @@ struct SettingsView: View {
         let key = editor.slotID.rawValue
         claudeProfileConfigDirInputs[key] = claudeProfileEditorConfigDir
         claudeProfileJSONInputs[key] = claudeProfileEditorJSON
+        claudeProfileNoteInputs[key] = claudeProfileEditorNote
         claudeProfileResult[key] = viewModel.saveClaudeProfile(
             slotID: editor.slotID,
             displayName: "Claude \(editor.slotID.rawValue)",
+            note: claudeProfileEditorNote,
             source: claudeProfileEditorSource,
             configDir: claudeProfileEditorConfigDir,
             credentialsJSON: claudeProfileEditorJSON
@@ -5195,6 +5211,7 @@ struct SettingsView: View {
         claudeProfileEditor = nil
         claudeProfileEditorConfigDir = ""
         claudeProfileEditorJSON = ""
+        claudeProfileEditorNote = ""
         claudeProfileEditorSource = .configDir
     }
 
@@ -5210,6 +5227,32 @@ struct SettingsView: View {
                     .foregroundStyle(settingsHintColor)
                     .lineSpacing(3)
                     .fixedSize(horizontal: false, vertical: true)
+
+                HStack(alignment: .center, spacing: 10) {
+                    Text(viewModel.localizedText("备注", "Note"))
+                        .font(settingsLabelFont)
+                        .foregroundStyle(settingsBodyColor)
+                        .frame(width: 60, alignment: .leading)
+
+                    TextField(
+                        "",
+                        text: $claudeProfileEditorNote,
+                        prompt: settingsInputPrompt(viewModel.localizedText("例如：工作 / 个人", "e.g. Work / Personal"))
+                    )
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 11, weight: .regular))
+                    .foregroundStyle(settingsBodyColor)
+                    .padding(.horizontal, 10)
+                    .frame(maxWidth: .infinity, minHeight: 24, maxHeight: 24, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(settingsInputFillColor)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(Color.black.opacity(0.08), lineWidth: 1)
+                    )
+                }
 
                 officialSegmentControl(
                     selection: $claudeProfileEditorSource,
@@ -5266,6 +5309,7 @@ struct SettingsView: View {
                     claudeProfileEditor = nil
                     claudeProfileEditorConfigDir = ""
                     claudeProfileEditorJSON = ""
+                    claudeProfileEditorNote = ""
                     claudeProfileEditorSource = .configDir
                 }
                 settingsCapsuleButton(viewModel.text(.save), dismissInputFocus: true) {
@@ -5414,6 +5458,7 @@ struct SettingsView: View {
     private func openCodexProfileEditor(slotID: CodexSlotID, existingProfile: CodexAccountProfile?) {
         let key = slotID.rawValue
         codexProfileEditorJSON = codexProfileJSONInputs[key] ?? existingProfile?.authJSON ?? ""
+        codexProfileEditorNote = codexProfileNoteInputs[key] ?? existingProfile?.note ?? ""
         codexProfileEditor = CodexProfileEditorState(
             slotID: slotID,
             title: viewModel.codexSettingsTitle(for: slotID),
@@ -5425,13 +5470,16 @@ struct SettingsView: View {
         guard let editor = codexProfileEditor else { return }
         let key = editor.slotID.rawValue
         codexProfileJSONInputs[key] = codexProfileEditorJSON
+        codexProfileNoteInputs[key] = codexProfileEditorNote
         codexProfileResult[key] = viewModel.saveCodexProfile(
             slotID: editor.slotID,
             displayName: "Codex \(editor.slotID.rawValue)",
+            note: codexProfileEditorNote,
             authJSON: codexProfileEditorJSON
         )
         codexProfileEditor = nil
         codexProfileEditorJSON = ""
+        codexProfileEditorNote = ""
     }
 
     private var codexProfileEditorDialog: some View {
@@ -5446,6 +5494,32 @@ struct SettingsView: View {
                     .foregroundStyle(settingsHintColor)
                     .lineSpacing(3)
                     .fixedSize(horizontal: false, vertical: true)
+
+                HStack(alignment: .center, spacing: 10) {
+                    Text(viewModel.localizedText("备注", "Note"))
+                        .font(settingsLabelFont)
+                        .foregroundStyle(settingsBodyColor)
+                        .frame(width: 60, alignment: .leading)
+
+                    TextField(
+                        "",
+                        text: $codexProfileEditorNote,
+                        prompt: settingsInputPrompt(viewModel.localizedText("例如：工作 / 个人", "e.g. Work / Personal"))
+                    )
+                    .textFieldStyle(.plain)
+                    .font(.system(size: 11, weight: .regular))
+                    .foregroundStyle(settingsBodyColor)
+                    .padding(.horizontal, 10)
+                    .frame(maxWidth: .infinity, minHeight: 24, maxHeight: 24, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(settingsInputFillColor)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(Color.black.opacity(0.08), lineWidth: 1)
+                    )
+                }
 
                 TextEditor(text: $codexProfileEditorJSON)
                     .font(.system(size: 11, weight: .regular, design: .monospaced))
@@ -5467,6 +5541,7 @@ struct SettingsView: View {
                 settingsCapsuleButton(viewModel.text(.permissionCancel)) {
                     codexProfileEditor = nil
                     codexProfileEditorJSON = ""
+                    codexProfileEditorNote = ""
                 }
                 settingsCapsuleButton(viewModel.text(.save), dismissInputFocus: true) {
                     saveCodexProfileEditor()
@@ -5493,6 +5568,16 @@ struct SettingsView: View {
             return editor.isNewSlot ? "添加 \(editor.title) auth.json" : "编辑 \(editor.title) auth.json"
         }
         return editor.isNewSlot ? "Add \(editor.title) auth.json" : "Edit \(editor.title) auth.json"
+    }
+
+    private func profileEmailWithNote(email: String?, note: String?, fallback: String) -> String {
+        let trimmedEmail = email?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedNote = note?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedEmail = (trimmedEmail?.isEmpty == false ? trimmedEmail! : fallback)
+        guard let trimmedNote, !trimmedNote.isEmpty else {
+            return resolvedEmail
+        }
+        return "\(resolvedEmail) · \(trimmedNote)"
     }
 
     private func codexSlotStatus(snapshot: UsageSnapshot?) -> (text: String, color: Color) {


### PR DESCRIPTION
为 Codex 和 Claude 个人资料添加了备注字段，允许用户在保存个人资料时输入备注信息。更新了相关的视图和数据模型，以支持备注的显示和存储。

- 更新了 CodexAccountProfile 和 ClaudeAccountProfile 模型
- 修改了保存个人资料的方法以包含备注参数
- 更新了用户界面以显示和编辑备注信息