### PR TITLE
feat: 添加更新后发布说明支持

### DIFF
--- a/Sources/AIPlanMonitor/App/AppViewModel.swift
+++ b/Sources/AIPlanMonitor/App/AppViewModel.swift
@@ -24,6 +24,7 @@ final class AppViewModel {
     private let claudeDesktopAuthService = ClaudeDesktopAuthService()
     private let launchAtLoginService = LaunchAtLoginService()
     private let notifications = NotificationService()
+    private let postUpdateReleaseNotesStore: any PostUpdateReleaseNotesStoring
     @ObservationIgnored private let localSessionSignalMonitor = LocalSessionCompletionSignalMonitor()
     private let providerFactory: ProviderFactory
     @ObservationIgnored private let localSessionRefreshCoordinator: LocalSessionRefreshCoordinator
@@ -82,6 +83,7 @@ final class AppViewModel {
     private var notificationPermissionPollingTask: Task<Void, Never>?
     @ObservationIgnored private var permissionRefreshTask: Task<Void, Never>?
     private var preparedUpdate: PreparedAppUpdate?
+    private var preparedUpdateInfo: AppUpdateInfo?
     private var updateFlowVersionInFlight: String?
     private var updateInstallBufferTask: Task<Void, Never>?
     private let updateInstallBufferDelaySeconds: TimeInterval
@@ -94,10 +96,12 @@ final class AppViewModel {
 
     init(
         appUpdateService: any AppUpdateServicing = AppUpdateService(),
+        postUpdateReleaseNotesStore: any PostUpdateReleaseNotesStoring = PostUpdateReleaseNotesStore(),
         updateInstallBufferDelaySeconds: TimeInterval = 5,
         updateCheckStatusClearDelaySeconds: TimeInterval = 10
     ) {
         self.appUpdateService = appUpdateService
+        self.postUpdateReleaseNotesStore = postUpdateReleaseNotesStore
         self.updateInstallBufferDelaySeconds = updateInstallBufferDelaySeconds
         self.updateCheckStatusClearDelaySeconds = updateCheckStatusClearDelaySeconds
         let shouldPersistConfigDuringBootstrap: Bool
@@ -149,10 +153,12 @@ final class AppViewModel {
         testingConfig: AppConfig = .default,
         testingCurrentAppVersion: String = "0.0.0",
         appUpdateService: any AppUpdateServicing,
+        postUpdateReleaseNotesStore: any PostUpdateReleaseNotesStoring = PostUpdateReleaseNotesStore(),
         updateInstallBufferDelaySeconds: TimeInterval = 5,
         updateCheckStatusClearDelaySeconds: TimeInterval = 10
     ) {
         self.appUpdateService = appUpdateService
+        self.postUpdateReleaseNotesStore = postUpdateReleaseNotesStore
         self.updateInstallBufferDelaySeconds = updateInstallBufferDelaySeconds
         self.updateCheckStatusClearDelaySeconds = updateCheckStatusClearDelaySeconds
         self.config = testingConfig.migratedWithSiteDefaults()
@@ -248,6 +254,17 @@ final class AppViewModel {
 
     func openRepositoryPage() {
         NSWorkspace.shared.open(AppUpdateService.repositoryURL)
+    }
+
+    func openCurrentVersionReleaseNotes() {
+        ReleaseNotesWindowController.shared.show(
+            releaseNotes: PendingPostUpdateReleaseNotes(
+                version: currentAppVersion,
+                releaseURL: AppUpdateService.releasePageURL(forVersion: currentAppVersion),
+                notesURL: nil,
+                createdAt: Date()
+            )
+        )
     }
 
     func openLatestReleaseDownload() {
@@ -745,6 +762,7 @@ final class AppViewModel {
 
     private func clearPreparedUpdateState() {
         preparedUpdate = nil
+        preparedUpdateInfo = nil
         updatePreparedVersion = nil
         updateFlowVersionInFlight = nil
         cancelUpdateInstallBuffering()
@@ -812,6 +830,9 @@ final class AppViewModel {
         updateInstallBufferingInFlight = false
         updateInstallErrorMessage = nil
         updateInstallationInFlight = true
+        if let preparedUpdateInfo, preparedUpdateInfo.latestVersion == preparedUpdate.version {
+            postUpdateReleaseNotesStore.schedulePresentation(for: preparedUpdateInfo)
+        }
 
         Task { [weak self] in
             guard let self else { return }
@@ -855,6 +876,7 @@ final class AppViewModel {
             do {
                 let prepared = try await self.appUpdateService.prepareUpdate(update)
                 self.preparedUpdate = prepared
+                self.preparedUpdateInfo = update
                 self.updatePreparedVersion = prepared.version
                 self.updateDownloadInFlight = false
                 self.updateFlowVersionInFlight = nil

--- a/Sources/AIPlanMonitor/App/ReleaseNotesWindowController.swift
+++ b/Sources/AIPlanMonitor/App/ReleaseNotesWindowController.swift
@@ -1,0 +1,252 @@
+import AppKit
+
+@MainActor
+final class ReleaseNotesWindowController: NSObject, NSWindowDelegate {
+    static let shared = ReleaseNotesWindowController()
+
+    private let releaseNotesService = AppUpdateService()
+    private let bodyFont = NSFont.systemFont(ofSize: 14)
+    private let minContentSize = NSSize(width: 520, height: 220)
+    private let maxContentSize = NSSize(width: 920, height: 720)
+    private let bodyHorizontalInset: CGFloat = 28
+    private let bodyVerticalInset: CGFloat = 28
+    private let extraScrollChromeWidth: CGFloat = 22
+    private let buttonRowHeight: CGFloat = 52
+    private var window: NSWindow?
+    private var textView: NSTextView?
+    private var openButton: NSButton?
+    private var currentReleaseURL: URL?
+    private var loadRequestID = UUID()
+
+    private override init() {
+        super.init()
+    }
+
+    func show(releaseNotes: PendingPostUpdateReleaseNotes) {
+        let window = ensureWindow()
+        window.title = title(for: releaseNotes.version)
+        currentReleaseURL = releaseNotes.releaseURL
+        loadRequestID = UUID()
+        setBodyText(loadingText())
+        NSApp.activate(ignoringOtherApps: true)
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+
+        let requestID = loadRequestID
+        Task { [weak self] in
+            guard let self else { return }
+
+            let bodyText: String
+            do {
+                let fetched = try await self.releaseNotesService.fetchReleaseNotesBody(
+                    forVersion: releaseNotes.version
+                )
+                bodyText = fetched.isEmpty ? self.emptyText() : fetched
+            } catch {
+                bodyText = self.failedText()
+            }
+
+            guard self.loadRequestID == requestID else { return }
+            self.setBodyText(bodyText)
+        }
+    }
+
+    private func ensureWindow() -> NSWindow {
+        if let window {
+            return window
+        }
+
+        let textView = NSTextView(frame: .zero)
+        textView.isEditable = false
+        textView.isRichText = false
+        textView.isSelectable = true
+        textView.importsGraphics = false
+        textView.drawsBackground = false
+        textView.font = bodyFont
+        textView.textColor = .labelColor
+        textView.textContainerInset = NSSize(width: 14, height: 14)
+        self.textView = textView
+
+        let scrollView = NSScrollView(frame: .zero)
+        scrollView.borderType = .noBorder
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.drawsBackground = false
+        scrollView.documentView = textView
+
+        let openButton = NSButton(
+            title: buttonTitle(),
+            target: self,
+            action: #selector(openReleasePage)
+        )
+        openButton.bezelStyle = .rounded
+        self.openButton = openButton
+
+        let buttonRow = NSStackView(views: [openButton])
+        buttonRow.orientation = .horizontal
+        buttonRow.alignment = .centerY
+        buttonRow.distribution = .gravityAreas
+        buttonRow.edgeInsets = NSEdgeInsets(top: 12, left: 16, bottom: 12, right: 16)
+
+        let contentStack = NSStackView(views: [scrollView, buttonRow])
+        contentStack.orientation = .vertical
+        contentStack.spacing = 0
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView(frame: .zero)
+        container.addSubview(contentStack)
+        NSLayoutConstraint.activate([
+            contentStack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            contentStack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            contentStack.topAnchor.constraint(equalTo: container.topAnchor),
+            contentStack.bottomAnchor.constraint(equalTo: container.bottomAnchor)
+        ])
+
+        let panel = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 920, height: 680),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        panel.titleVisibility = .visible
+        panel.isReleasedWhenClosed = false
+        panel.delegate = self
+        panel.minSize = frameSize(forContentSize: minContentSize)
+        panel.contentView = container
+        self.window = panel
+        return panel
+    }
+
+    private func setBodyText(_ text: String) {
+        textView?.string = text
+        updateWindowSize(for: text)
+        textView?.scrollToBeginningOfDocument(nil)
+    }
+
+    private func updateWindowSize(for text: String) {
+        guard let window else { return }
+
+        let contentSize = preferredContentSize(for: text)
+        let targetFrameSize = frameSize(forContentSize: contentSize)
+        let currentFrame = window.frame
+        let newOrigin = NSPoint(
+            x: currentFrame.midX - targetFrameSize.width / 2,
+            y: currentFrame.midY - targetFrameSize.height / 2
+        )
+
+        window.setFrame(
+            NSRect(origin: newOrigin, size: targetFrameSize),
+            display: true,
+            animate: true
+        )
+    }
+
+    private func preferredContentSize(for text: String) -> NSSize {
+        let maxAvailableSize = maximumAvailableContentSize()
+        let clampedMaxWidth = min(maxAvailableSize.width, maxContentSize.width)
+        let clampedMaxHeight = min(maxAvailableSize.height, maxContentSize.height)
+        let width = preferredBodyWidth(for: text, maximumContentWidth: clampedMaxWidth)
+        let bodyHeight = preferredBodyHeight(
+            for: text,
+            bodyWidth: width - bodyHorizontalInset - extraScrollChromeWidth
+        )
+
+        return NSSize(
+            width: min(max(minContentSize.width, width), clampedMaxWidth),
+            height: min(
+                max(minContentSize.height, bodyHeight + bodyVerticalInset + buttonRowHeight),
+                clampedMaxHeight
+            )
+        )
+    }
+
+    private func preferredBodyWidth(for text: String, maximumContentWidth: CGFloat) -> CGFloat {
+        let maxBodyWidth = maximumContentWidth - bodyHorizontalInset - extraScrollChromeWidth
+        let minBodyWidth = minContentSize.width - bodyHorizontalInset - extraScrollChromeWidth
+        let widestLine = text
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map { String($0) }
+            .reduce(CGFloat.zero) { partialResult, line in
+                max(partialResult, measuredSingleLineWidth(for: line))
+            }
+
+        let targetBodyWidth = min(max(minBodyWidth, widestLine), maxBodyWidth)
+        return targetBodyWidth + bodyHorizontalInset + extraScrollChromeWidth
+    }
+
+    private func preferredBodyHeight(for text: String, bodyWidth: CGFloat) -> CGFloat {
+        let constrainedWidth = max(200, bodyWidth)
+        let measured = (text as NSString).boundingRect(
+            with: NSSize(width: constrainedWidth, height: .greatestFiniteMagnitude),
+            options: [.usesLineFragmentOrigin, .usesFontLeading],
+            attributes: [.font: bodyFont],
+            context: nil
+        )
+        return ceil(measured.height)
+    }
+
+    private func measuredSingleLineWidth(for line: String) -> CGFloat {
+        let candidate = line.isEmpty ? " " : line
+        let measured = (candidate as NSString).size(withAttributes: [.font: bodyFont])
+        return ceil(measured.width)
+    }
+
+    private func maximumAvailableContentSize() -> NSSize {
+        guard let visibleFrame = NSScreen.main?.visibleFrame else {
+            return maxContentSize
+        }
+        return NSSize(
+            width: max(minContentSize.width, visibleFrame.width - 120),
+            height: max(minContentSize.height, visibleFrame.height - 120)
+        )
+    }
+
+    private func frameSize(forContentSize contentSize: NSSize) -> NSSize {
+        guard let window else {
+            return contentSize
+        }
+        return window.frameRect(forContentRect: NSRect(origin: .zero, size: contentSize)).size
+    }
+
+    private func title(for version: String) -> String {
+        if Locale.preferredLanguages.first?.lowercased().hasPrefix("zh") == true {
+            return "AI Plan Monitor \(version) 更新说明"
+        }
+        return "AI Plan Monitor \(version) Release Notes"
+    }
+
+    private func buttonTitle() -> String {
+        if Locale.preferredLanguages.first?.lowercased().hasPrefix("zh") == true {
+            return "打开 Release 页面"
+        }
+        return "Open Release Page"
+    }
+
+    private func loadingText() -> String {
+        if Locale.preferredLanguages.first?.lowercased().hasPrefix("zh") == true {
+            return "正在加载当前版本的更新说明…"
+        }
+        return "Loading release notes for this version..."
+    }
+
+    private func emptyText() -> String {
+        if Locale.preferredLanguages.first?.lowercased().hasPrefix("zh") == true {
+            return "当前版本没有填写更新说明。"
+        }
+        return "No release notes were provided for this version."
+    }
+
+    private func failedText() -> String {
+        if Locale.preferredLanguages.first?.lowercased().hasPrefix("zh") == true {
+            return "加载更新说明失败。你仍然可以点击下方按钮打开 Release 页面查看。"
+        }
+        return "Failed to load the release notes. You can still open the release page below."
+    }
+
+    @objc
+    private func openReleasePage() {
+        guard let currentReleaseURL else { return }
+        NSWorkspace.shared.open(currentReleaseURL)
+    }
+}

--- a/Sources/AIPlanMonitor/App/RuntimeGuards.swift
+++ b/Sources/AIPlanMonitor/App/RuntimeGuards.swift
@@ -55,6 +55,7 @@ final class SingleInstanceLock {
 final class AppLifecycleDelegate: NSObject, NSApplicationDelegate {
     private var statusBarController: StatusBarController?
     private var activationObserver: NSObjectProtocol?
+    private let postUpdateReleaseNotesStore: any PostUpdateReleaseNotesStoring = PostUpdateReleaseNotesStore()
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Ensure app stays menu-bar only even if started from terminal context.
@@ -68,7 +69,9 @@ final class AppLifecycleDelegate: NSObject, NSApplicationDelegate {
         }
 
         startActivationBridgeObservation()
-        statusBarController = StatusBarController(viewModel: AppViewModel())
+        let viewModel = AppViewModel()
+        statusBarController = StatusBarController(viewModel: viewModel)
+        presentPostUpdateReleaseNotesIfNeeded(currentVersion: viewModel.currentAppVersion)
     }
 
     func applicationWillTerminate(_ notification: Notification) {
@@ -115,5 +118,18 @@ final class AppLifecycleDelegate: NSObject, NSApplicationDelegate {
         guard let activationObserver else { return }
         DistributedNotificationCenter.default().removeObserver(activationObserver)
         self.activationObserver = nil
+    }
+
+    @MainActor
+    private func presentPostUpdateReleaseNotesIfNeeded(currentVersion: String) {
+        guard let releaseNotes = postUpdateReleaseNotesStore.consumePresentationIfNeeded(
+            currentVersion: currentVersion
+        ) else {
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+            ReleaseNotesWindowController.shared.show(releaseNotes: releaseNotes)
+        }
     }
 }

--- a/Sources/AIPlanMonitor/Services/AppUpdateService.swift
+++ b/Sources/AIPlanMonitor/Services/AppUpdateService.swift
@@ -62,6 +62,7 @@ actor AppUpdateService {
     static let repositoryURL = URL(string: "https://github.com/\(owner)/\(repository)")!
     static let releasesURL = URL(string: "https://github.com/\(owner)/\(repository)/releases/latest")!
     static let metadataURL = URL(string: "https://github.com/\(owner)/\(repository)/releases/latest/download/latest.json")!
+    static let apiBaseURL = URL(string: "https://api.github.com/repos/\(owner)/\(repository)")!
 
     private struct ReleaseManifest: Decodable {
         var version: String
@@ -93,6 +94,10 @@ actor AppUpdateService {
             case notesURL = "notes_url"
             case assets
         }
+    }
+
+    private struct GitHubReleaseResponse: Decodable {
+        var body: String?
     }
 
     private let session: URLSession
@@ -137,6 +142,39 @@ actor AppUpdateService {
             zipAsset: manifest.assets.macOSZip.map { AppUpdateAsset(url: $0.url, sha256: $0.sha256, size: $0.size) },
             dmgAsset: manifest.assets.macOSDMG.map { AppUpdateAsset(url: $0.url, sha256: $0.sha256, size: $0.size) }
         )
+    }
+
+    func fetchReleaseNotesBody(forVersion version: String) async throws -> String {
+        let candidates = Self.releaseTagCandidates(forVersion: version)
+
+        for tag in candidates {
+            let endpoint = Self.apiBaseURL
+                .appendingPathComponent("releases", isDirectory: true)
+                .appendingPathComponent("tags", isDirectory: true)
+                .appendingPathComponent(tag)
+
+            var request = URLRequest(url: endpoint)
+            request.httpMethod = "GET"
+            request.timeoutInterval = 15
+            request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+            request.setValue("AIPlanMonitor", forHTTPHeaderField: "User-Agent")
+
+            let (data, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                throw URLError(.badServerResponse)
+            }
+            if http.statusCode == 404 {
+                continue
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                throw URLError(.badServerResponse)
+            }
+
+            let release = try JSONDecoder().decode(GitHubReleaseResponse.self, from: data)
+            return release.body?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        }
+
+        throw URLError(.fileDoesNotExist)
     }
 
     func prepareUpdate(_ update: AppUpdateInfo) async throws -> PreparedAppUpdate {
@@ -226,6 +264,29 @@ actor AppUpdateService {
             return String(trimmed.dropFirst())
         }
         return trimmed
+    }
+
+    static func releasePageURL(forVersion version: String) -> URL {
+        let tag = releaseTagCandidates(forVersion: version).first ?? version
+        return repositoryURL
+            .appendingPathComponent("releases", isDirectory: true)
+            .appendingPathComponent("tag", isDirectory: true)
+            .appendingPathComponent(tag)
+    }
+
+    static func releaseTagCandidates(forVersion version: String) -> [String] {
+        let normalized = normalizeVersion(version)
+        guard !normalized.isEmpty else { return [] }
+
+        let tags: [String] = ["v\(normalized)", normalized]
+        var deduped: [String] = []
+        var seen = Set<String>()
+        for tag in tags {
+            if seen.insert(tag).inserted {
+                deduped.append(tag)
+            }
+        }
+        return deduped
     }
 
     private static func sha256Hex(for fileURL: URL) throws -> String {

--- a/Sources/AIPlanMonitor/Services/PostUpdateReleaseNotesStore.swift
+++ b/Sources/AIPlanMonitor/Services/PostUpdateReleaseNotesStore.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+struct PendingPostUpdateReleaseNotes: Codable, Equatable {
+    var version: String
+    var releaseURL: URL
+    var notesURL: URL?
+    var createdAt: Date
+
+    var displayURL: URL {
+        notesURL ?? releaseURL
+    }
+}
+
+protocol PostUpdateReleaseNotesStoring: AnyObject {
+    func schedulePresentation(for update: AppUpdateInfo)
+    func consumePresentationIfNeeded(currentVersion: String) -> PendingPostUpdateReleaseNotes?
+    func reset()
+}
+
+final class PostUpdateReleaseNotesStore: PostUpdateReleaseNotesStoring {
+    private static let pendingDefaultsKey = "AIPlanMonitor.PendingPostUpdateReleaseNotes"
+
+    private let defaults: UserDefaults
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        encoder.dateEncodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    func schedulePresentation(for update: AppUpdateInfo) {
+        let pending = PendingPostUpdateReleaseNotes(
+            version: AppUpdateService.normalizeVersion(update.latestVersion),
+            releaseURL: update.releaseURL,
+            notesURL: update.notesURL,
+            createdAt: Date()
+        )
+        guard let data = try? encoder.encode(pending) else { return }
+        defaults.set(data, forKey: Self.pendingDefaultsKey)
+    }
+
+    func consumePresentationIfNeeded(currentVersion: String) -> PendingPostUpdateReleaseNotes? {
+        guard let pending = loadPendingPresentation() else { return nil }
+
+        let normalizedCurrentVersion = AppUpdateService.normalizeVersion(currentVersion)
+        let normalizedPendingVersion = AppUpdateService.normalizeVersion(pending.version)
+
+        if normalizedCurrentVersion == normalizedPendingVersion {
+            reset()
+            return pending
+        }
+
+        if Self.isVersion(normalizedCurrentVersion, newerThan: normalizedPendingVersion) {
+            reset()
+        }
+
+        return nil
+    }
+
+    func reset() {
+        defaults.removeObject(forKey: Self.pendingDefaultsKey)
+    }
+
+    private func loadPendingPresentation() -> PendingPostUpdateReleaseNotes? {
+        guard let data = defaults.data(forKey: Self.pendingDefaultsKey) else {
+            return nil
+        }
+        guard let pending = try? decoder.decode(PendingPostUpdateReleaseNotes.self, from: data) else {
+            defaults.removeObject(forKey: Self.pendingDefaultsKey)
+            return nil
+        }
+        return pending
+    }
+
+    private static func isVersion(_ lhs: String, newerThan rhs: String) -> Bool {
+        let left = parseVersionComponents(lhs)
+        let right = parseVersionComponents(rhs)
+        let maxCount = max(left.count, right.count)
+
+        for index in 0..<maxCount {
+            let l = index < left.count ? left[index] : 0
+            let r = index < right.count ? right[index] : 0
+            if l != r {
+                return l > r
+            }
+        }
+        return false
+    }
+
+    private static func parseVersionComponents(_ raw: String) -> [Int] {
+        AppUpdateService.normalizeVersion(raw)
+            .split(separator: ".")
+            .map { part in
+                let digits = part.prefix { $0.isNumber }
+                return Int(digits) ?? 0
+            }
+    }
+}

--- a/Sources/AIPlanMonitor/UI/SettingsView.swift
+++ b/Sources/AIPlanMonitor/UI/SettingsView.swift
@@ -618,12 +618,20 @@ struct SettingsView: View {
                     .layoutPriority(3)
             }
 
-            settingsTopMetaItem(
-                text: currentVersionTitle,
-                iconName: "settings_version_icon",
-                fallbackIcon: "chevron.left.forwardslash.chevron.right",
-                textColor: settingsHintColor
-            )
+            Button {
+                viewModel.openCurrentVersionReleaseNotes()
+            } label: {
+                settingsTopMetaItem(
+                    text: currentVersionTitle,
+                    iconName: "settings_version_icon",
+                    fallbackIcon: "chevron.left.forwardslash.chevron.right",
+                    textColor: settingsHintColor
+                )
+                .padding(.horizontal, 4)
+                .frame(height: 24)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
 
             Button {
                 viewModel.checkForAppUpdate(force: true)

--- a/Tests/AIPlanMonitorTests/AppViewModelUpdateFlowTests.swift
+++ b/Tests/AIPlanMonitorTests/AppViewModelUpdateFlowTests.swift
@@ -6,6 +6,7 @@ import XCTest
 final class AppViewModelUpdateFlowTests: XCTestCase {
     func testDownloadSuccessTransitionsToBufferingThenAttemptsInstall() async {
         let service = StubAppUpdateService()
+        let releaseNotesStore = StubPostUpdateReleaseNotesStore()
         await service.enqueueFetch(.success(makeUpdate(version: "2.0.0")))
         await service.enqueuePrepare(.success(makePrepared(version: "2.0.0")))
         await service.enqueueInstall(.failure(StubUpdateError.installFailed))
@@ -13,6 +14,7 @@ final class AppViewModelUpdateFlowTests: XCTestCase {
         let viewModel = AppViewModel(
             testingCurrentAppVersion: "1.0.0",
             appUpdateService: service,
+            postUpdateReleaseNotesStore: releaseNotesStore,
             updateInstallBufferDelaySeconds: 0.12
         )
 
@@ -32,6 +34,7 @@ final class AppViewModelUpdateFlowTests: XCTestCase {
         await assertEventually("should attempt install after buffering delay") {
             await service.installCallCount() == 1
         }
+        XCTAssertEqual(releaseNotesStore.scheduledVersions, ["2.0.0"])
         await assertEventually("failed install should expose retry state") {
             if case .failed = viewModel.menuUpdateDisplayState.kind {
                 return viewModel.updateInstallErrorMessage != nil
@@ -211,6 +214,29 @@ final class AppViewModelUpdateFlowTests: XCTestCase {
         let finalResult = await condition()
         XCTAssertTrue(finalResult, message)
     }
+}
+
+private final class StubPostUpdateReleaseNotesStore: PostUpdateReleaseNotesStoring {
+    private let lock = NSLock()
+    private var storedScheduledVersions: [String] = []
+
+    var scheduledVersions: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedScheduledVersions
+    }
+
+    func schedulePresentation(for update: AppUpdateInfo) {
+        lock.lock()
+        storedScheduledVersions.append(update.latestVersion)
+        lock.unlock()
+    }
+
+    func consumePresentationIfNeeded(currentVersion: String) -> PendingPostUpdateReleaseNotes? {
+        nil
+    }
+
+    func reset() {}
 }
 
 private actor StubAppUpdateService: AppUpdateServicing {

--- a/Tests/AIPlanMonitorTests/PostUpdateReleaseNotesStoreTests.swift
+++ b/Tests/AIPlanMonitorTests/PostUpdateReleaseNotesStoreTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import XCTest
+@testable import AIPlanMonitor
+
+final class PostUpdateReleaseNotesStoreTests: XCTestCase {
+    func testConsumeReturnsPendingReleaseNotesWhenCurrentVersionMatches() {
+        let defaults = UserDefaults(suiteName: "PostUpdateReleaseNotesStoreTests.match.\(UUID().uuidString)")!
+        let store = PostUpdateReleaseNotesStore(defaults: defaults)
+
+        store.schedulePresentation(for: makeUpdate(version: "2.1.0"))
+
+        let pending = store.consumePresentationIfNeeded(currentVersion: "2.1.0")
+
+        XCTAssertEqual(pending?.version, "2.1.0")
+        XCTAssertEqual(pending?.displayURL, URL(string: "https://example.com/notes/2.1.0")!)
+        XCTAssertNil(store.consumePresentationIfNeeded(currentVersion: "2.1.0"))
+    }
+
+    func testConsumeKeepsPendingReleaseNotesWhenCurrentVersionIsOlder() {
+        let defaults = UserDefaults(suiteName: "PostUpdateReleaseNotesStoreTests.older.\(UUID().uuidString)")!
+        let store = PostUpdateReleaseNotesStore(defaults: defaults)
+
+        store.schedulePresentation(for: makeUpdate(version: "2.1.0"))
+
+        XCTAssertNil(store.consumePresentationIfNeeded(currentVersion: "2.0.9"))
+        XCTAssertEqual(
+            store.consumePresentationIfNeeded(currentVersion: "2.1.0")?.version,
+            "2.1.0"
+        )
+    }
+
+    func testConsumeDropsStalePendingReleaseNotesWhenCurrentVersionIsNewer() {
+        let defaults = UserDefaults(suiteName: "PostUpdateReleaseNotesStoreTests.newer.\(UUID().uuidString)")!
+        let store = PostUpdateReleaseNotesStore(defaults: defaults)
+
+        store.schedulePresentation(for: makeUpdate(version: "2.1.0"))
+
+        XCTAssertNil(store.consumePresentationIfNeeded(currentVersion: "2.2.0"))
+        XCTAssertNil(store.consumePresentationIfNeeded(currentVersion: "2.1.0"))
+    }
+
+    private func makeUpdate(version: String) -> AppUpdateInfo {
+        AppUpdateInfo(
+            latestVersion: version,
+            releaseURL: URL(string: "https://example.com/releases/\(version)")!,
+            notesURL: URL(string: "https://example.com/notes/\(version)")!,
+            publishedAt: nil,
+            zipAsset: nil,
+            dmgAsset: nil
+        )
+    }
+}


### PR DESCRIPTION
- 引入 PostUpdateReleaseNotesStore 以存储和管理更新后的发布说明
- 在 AppViewModel 中集成发布说明的调度和展示逻辑
- 新增 ReleaseNotesWindowController 以显示当前版本的更新说明
- 更新设置视图以允许用户打开当前版本的发布说明