### PR TITLE
重构设置页并修复外观模式适配

### DIFF
--- a/Sources/AIPlanMonitor/App/SettingsWindowController.swift
+++ b/Sources/AIPlanMonitor/App/SettingsWindowController.swift
@@ -7,18 +7,22 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
 
     private var window: NSWindow?
     private var hostingController: NSHostingController<AnyView>?
+    private var activationPolicyBeforeShowingSettings: NSApplication.ActivationPolicy?
 
     private override init() {
         super.init()
     }
 
     func show(viewModel: AppViewModel) {
-        let targetContentSize = NSSize(width: 960, height: 670)
+        showAppInDockForSettingsWindow()
+
+        let initialContentSize = NSSize(width: 1416, height: 912)
+        let minimumContentSize = NSSize(width: 1248, height: 816)
         if window == nil {
-            // 窗口基础尺寸：对应设置页整体画布宽高（与 Figma 画板尺寸对齐）。
+            // 窗口基础尺寸：首次打开使用推荐尺寸，之后允许用户自由拖拽调整。
             let panel = NSWindow(
-                contentRect: NSRect(origin: .zero, size: targetContentSize),
-                styleMask: [.titled, .closable, .miniaturizable, .fullSizeContentView],
+                contentRect: NSRect(origin: .zero, size: initialContentSize),
+                styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
                 backing: .buffered,
                 defer: false
             )
@@ -48,23 +52,25 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
             panel.isMovableByWindowBackground = true
             panel.isReleasedWhenClosed = false
             panel.delegate = self
-            // 固定“内容区”为 960x670（min/max 需使用 frameRect 尺寸）。
-            let fixedFrameSize = panel.frameRect(
-                forContentRect: NSRect(origin: .zero, size: targetContentSize)
+            let minimumFrameSize = panel.frameRect(
+                forContentRect: NSRect(origin: .zero, size: minimumContentSize)
             ).size
-            panel.minSize = fixedFrameSize
-            panel.maxSize = fixedFrameSize
-            panel.setContentSize(targetContentSize)
+            panel.minSize = minimumFrameSize
+            panel.setContentSize(initialContentSize)
             panel.center()
             window = panel
         }
 
         let rootView = AnyView(
             SettingsView(viewModel: viewModel, onDone: { [weak self] in
-                self?.window?.orderOut(nil)
+                self?.hideSettingsWindow()
             })
-            // SwiftUI 内容区尺寸：与目标 contentRect 保持一致。
-            .frame(width: targetContentSize.width, height: targetContentSize.height)
+            .frame(
+                minWidth: minimumContentSize.width,
+                maxWidth: .infinity,
+                minHeight: minimumContentSize.height,
+                maxHeight: .infinity
+            )
         )
 
         if let hostingController {
@@ -74,7 +80,6 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
             hostingController = controller
             window?.contentViewController = controller
         }
-        window?.setContentSize(targetContentSize)
         ensureSingleBorderContentAppearance()
 
         NSApp.activate(ignoringOtherApps: true)
@@ -91,6 +96,29 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
     func windowDidResize(_ notification: Notification) {
         guard let panel = notification.object as? NSWindow else { return }
         layoutTrafficLights(in: panel)
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        restoreActivationPolicyAfterSettingsWindow()
+    }
+
+    private func showAppInDockForSettingsWindow() {
+        guard NSApp.activationPolicy() != .regular else { return }
+        if activationPolicyBeforeShowingSettings == nil {
+            activationPolicyBeforeShowingSettings = NSApp.activationPolicy()
+        }
+        NSApp.setActivationPolicy(.regular)
+    }
+
+    private func hideSettingsWindow() {
+        window?.orderOut(nil)
+        restoreActivationPolicyAfterSettingsWindow()
+    }
+
+    private func restoreActivationPolicyAfterSettingsWindow() {
+        guard let activationPolicyBeforeShowingSettings else { return }
+        NSApp.setActivationPolicy(activationPolicyBeforeShowingSettings)
+        self.activationPolicyBeforeShowingSettings = nil
     }
 
     private func ensureSingleBorderContentAppearance() {

--- a/Sources/AIPlanMonitor/App/SettingsWindowController.swift
+++ b/Sources/AIPlanMonitor/App/SettingsWindowController.swift
@@ -39,15 +39,8 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
             panel.setContentBorderThickness(0, for: .minY)
             // 整个窗口使用纯不透明背景。
             panel.isOpaque = true
-            // 窗口背景色（标题栏和内容区外层底色）。
-            panel.backgroundColor = NSColor(
-                red: 35.0 / 255.0,
-                green: 35.0 / 255.0,
-                blue: 35.0 / 255.0,
-                alpha: 1
-            )
-            // 强制深色外观，避免跟随系统浅色导致样式偏差。
-            panel.appearance = NSAppearance(named: .darkAqua)
+            // 首次创建时使用深色兜底；展示前会按当前设置外观重新应用。
+            SettingsWindowAppearanceResolver.apply(to: panel, usesLightAppearance: false)
             // 允许拖动背景区域移动窗口，避免顶部透明区域无法拖动。
             panel.isMovableByWindowBackground = true
             panel.isReleasedWhenClosed = false
@@ -59,6 +52,10 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
             panel.setContentSize(initialContentSize)
             panel.center()
             window = panel
+        }
+
+        if let panel = window {
+            applySettingsWindowAppearance(to: panel, mode: viewModel.statusBarAppearanceMode)
         }
 
         let rootView = AnyView(
@@ -128,6 +125,20 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         contentView.layer?.borderWidth = 0
         contentView.layer?.cornerRadius = 0
         contentView.layer?.masksToBounds = false
+    }
+
+    private func applySettingsWindowAppearance(
+        to panel: NSWindow,
+        mode: StatusBarAppearanceMode
+    ) {
+        let luminance = mode == .followWallpaper
+            ? SettingsWindowAppearanceResolver.wallpaperLuminance(for: panel.screen ?? NSScreen.main)
+            : nil
+        let usesLightAppearance = SettingsWindowAppearanceResolver.usesLightAppearance(
+            mode: mode,
+            wallpaperLuminance: luminance
+        )
+        SettingsWindowAppearanceResolver.apply(to: panel, usesLightAppearance: usesLightAppearance)
     }
 
     private func layoutTrafficLights(in panel: NSWindow) {

--- a/Sources/AIPlanMonitor/UI/SettingsView.swift
+++ b/Sources/AIPlanMonitor/UI/SettingsView.swift
@@ -88,31 +88,50 @@ struct SettingsView: View {
     @State private var localUsageTrendSelectedAccountKeys: [String: String] = [:]
     @State private var localUsageTrendQueryLastRefreshedAt: [String: Date] = [:]
     @State private var localUsageTrendExpandedAccountSelectorProviderID: String?
+    @State private var settingsWallpaperLuminance: Double?
 
     private let settingsClock = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     private let localUsageTrendRefreshTTL: TimeInterval = 60
 
     // MARK: - 设置页视觉 Token（改这里可全局影响样式）
-    // 整个设置页外层深色圆角容器背景。
-    private let panelBackground = Color(hex: 0x232323)
-    // “通用设置”主内容滚动区域的纯黑底。
-    private let cardBackground = Color.black
-    // 通用描边色：用于模型面板、卡片边框等 30% 白色描边，保证暗底可见性。
-    private let outlineColor = Color.white.opacity(0.30)
+    // 整个设置页外层背景。
+    private var panelBackground: Color {
+        settingsUsesLightAppearance ? Color(hex: 0xF3F4F6) : Color(hex: 0x232323)
+    }
+
+    // “通用设置”主内容滚动区域底色。
+    private var cardBackground: Color {
+        settingsUsesLightAppearance ? Color(hex: 0xFFFFFF) : Color.black
+    }
+
+    // 通用描边色：用于模型面板、卡片边框等。
+    private var outlineColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.14) : Color.white.opacity(0.30)
+    }
     // 内层卡片/黑色内容容器圆角。
     private let cardCornerRadius: CGFloat = 8
     private let settingsShellCornerRadius: CGFloat = 20
     private let settingsSidebarCornerRadius: CGFloat = 20
     private let settingsSectionCornerRadius: CGFloat = 8
-    private let settingsShellStrokeColor = Color.white.opacity(0.08)
-    private let settingsSidebarFillColor = Color.white.opacity(0.03)
-    private let settingsSectionFillColor = Color.white.opacity(0.04)
+    private var settingsShellStrokeColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.08) : Color.white.opacity(0.08)
+    }
+
+    private var settingsSidebarFillColor: Color {
+        settingsUsesLightAppearance ? Color.white.opacity(0.78) : Color.white.opacity(0.03)
+    }
+
+    private var settingsSectionFillColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.035) : Color.white.opacity(0.04)
+    }
     private let settingsAccentBlue = Color(hex: 0x168DFF)
     private let settingsAccentGreen = Color(hex: 0x31D158)
     private let settingsAccentPurple = Color(hex: 0xC93BFF)
     private let settingsAccentCyan = Color(hex: 0x12D6F3)
-    // 分割线颜色（与 15% 白描边风格一致）。
-    private let dividerColor = Color.white.opacity(0.15)
+    // 分割线颜色。
+    private var dividerColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.12) : Color.white.opacity(0.15)
+    }
     // 模型设置详情项垂直间距（设计稿统一 24px）。
     private let modelSettingsItemSpacing: CGFloat = 24
     // 本地扫描区内部内容项间距（设计稿统一 12px）。
@@ -132,19 +151,90 @@ struct SettingsView: View {
     private let settingsHintMultilineSpacing: CGFloat = 3
 
     // 标题文字颜色。
-    private let settingsTitleColor = Color.white.opacity(0.80)
+    private var settingsTitleColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.82) : Color.white.opacity(0.80)
+    }
+
     // 常规正文颜色。
-    private let settingsBodyColor = Color.white.opacity(0.80)
-    // 次级提示色（55% 白）。
-    private let settingsHintColor = Color.white.opacity(0.55)
-    // 更弱提示色（40% 白），用于“检查失败”等弱错误提示。
-    private let settingsMutedHintColor = Color.white.opacity(0.40)
+    private var settingsBodyColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.78) : Color.white.opacity(0.80)
+    }
+
+    // 次级提示色。
+    private var settingsHintColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.56) : Color.white.opacity(0.55)
+    }
+
+    // 更弱提示色，用于“检查失败”等弱错误提示。
+    private var settingsMutedHintColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.40) : Color.white.opacity(0.40)
+    }
     private let settingsUpdatePositiveColor = Color(hex: 0x69BD64)
     private let settingsUpdateNegativeColor = Color(hex: 0xD05757)
-    // 输入框填充色（white_15）。
-    private let settingsInputFillColor = Color.white.opacity(0.15)
-    // 输入框占位色（white_30）。
-    private let settingsInputPlaceholderColor = Color.white.opacity(0.30)
+    // 输入框填充色。
+    private var settingsInputFillColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.06) : Color.white.opacity(0.15)
+    }
+
+    // 输入框占位色。
+    private var settingsInputPlaceholderColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.35) : Color.white.opacity(0.30)
+    }
+    private var settingsSubtlePanelFillColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.035) : Color.white.opacity(0.03)
+    }
+
+    private var settingsSubtlePanelStrokeColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.08) : Color.white.opacity(0.06)
+    }
+
+    private var settingsSelectedRowFillColor: Color {
+        settingsUsesLightAppearance ? settingsAccentBlue.opacity(0.12) : Color.white.opacity(0.30)
+    }
+
+    private var settingsSelectedRowStrokeColor: Color {
+        settingsUsesLightAppearance ? settingsAccentBlue.opacity(0.52) : Color.white.opacity(0.80)
+    }
+
+    private var settingsRowStrokeColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.12) : Color.white.opacity(0.30)
+    }
+
+    private var settingsDropIndicatorColor: Color {
+        settingsUsesLightAppearance ? settingsAccentBlue.opacity(0.90) : Color.white.opacity(0.90)
+    }
+
+    private var settingsControlFillColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.05) : Color(hex: 0x2A2B2F)
+    }
+
+    private var settingsControlStrokeColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.12) : Color.white.opacity(0.12)
+    }
+
+    private var settingsPopoverFillColor: Color {
+        settingsUsesLightAppearance ? Color.white : Color(hex: 0x1F2024)
+    }
+
+    private var settingsPopoverSelectedFillColor: Color {
+        settingsUsesLightAppearance ? settingsAccentBlue.opacity(0.12) : Color.white.opacity(0.12)
+    }
+
+    private var settingsQuotaTrackColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.14) : Color.white.opacity(0.30)
+    }
+
+    private var settingsTrendPrimaryColor: Color {
+        settingsUsesLightAppearance ? settingsAccentBlue.opacity(0.78) : Color.white.opacity(0.62)
+    }
+
+    private var settingsTrendMutedColor: Color {
+        settingsUsesLightAppearance ? Color.black.opacity(0.16) : Color.white.opacity(0.22)
+    }
+
+    private var settingsSliderTintColor: Color {
+        settingsUsesLightAppearance ? settingsAccentBlue : Color.white.opacity(0.80)
+    }
     // API 余额页右侧配置项统一标签列宽（设计稿为 60）。
     private let thirdPartyConfigLabelWidth: CGFloat = 60
     private let thirdPartyConfigLabelSpacing: CGFloat = 12
@@ -302,18 +392,29 @@ struct SettingsView: View {
         }
         // 设置内容需要覆盖标题栏区域，避免系统安全区留下顶部分层。
         .ignoresSafeArea()
-        .environment(\.colorScheme, .dark)
+        .environment(\.colorScheme, settingsColorScheme)
         .onAppear {
             seedInputsFromConfig()
             syncSelection()
             resetProviderReorderState()
+            refreshSettingsAppearanceSample()
+            applySettingsWindowAppearance()
             viewModel.refreshPermissionStatusesNow()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            refreshSettingsAppearanceSample()
+            applySettingsWindowAppearance()
             viewModel.refreshPermissionStatusesNow()
         }
         .onReceive(settingsClock) { value in
             settingsNow = value
+        }
+        .onChange(of: viewModel.statusBarAppearanceMode) { _, _ in
+            refreshSettingsAppearanceSample()
+            applySettingsWindowAppearance()
+        }
+        .onChange(of: settingsWallpaperLuminance) { _, _ in
+            applySettingsWindowAppearance()
         }
         .onChange(of: viewModel.config.providers.map(\.id)) { _, _ in
             seedInputsFromConfig()
@@ -430,6 +531,31 @@ struct SettingsView: View {
             .padding(.bottom, 16)
             .padding(.top, 44)
         }
+    }
+
+    private var settingsColorScheme: ColorScheme {
+        settingsUsesLightAppearance ? .light : .dark
+    }
+
+    private var settingsUsesLightAppearance: Bool {
+        SettingsWindowAppearanceResolver.usesLightAppearance(
+            mode: viewModel.statusBarAppearanceMode,
+            wallpaperLuminance: settingsWallpaperLuminance
+        )
+    }
+
+    private func refreshSettingsAppearanceSample() {
+        guard viewModel.statusBarAppearanceMode == .followWallpaper else {
+            settingsWallpaperLuminance = nil
+            return
+        }
+        let screen = NSApp.keyWindow?.screen ?? NSScreen.main
+        settingsWallpaperLuminance = SettingsWindowAppearanceResolver.wallpaperLuminance(for: screen)
+    }
+
+    private func applySettingsWindowAppearance() {
+        guard let window = NSApp.windows.first(where: { $0.title == "AI Plan Monitor Settings" }) ?? NSApp.keyWindow ?? NSApp.mainWindow else { return }
+        SettingsWindowAppearanceResolver.apply(to: window, usesLightAppearance: settingsUsesLightAppearance)
     }
 
     private var settingsNavigationSidebar: some View {
@@ -618,11 +744,11 @@ struct SettingsView: View {
         .padding(.vertical, 10)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color.white.opacity(0.03))
+                .fill(settingsSubtlePanelFillColor)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(Color.white.opacity(0.06), lineWidth: 1)
+                .stroke(settingsSubtlePanelStrokeColor, lineWidth: 1)
         )
     }
 
@@ -651,11 +777,11 @@ struct SettingsView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(Color.white.opacity(0.03))
+                    .fill(settingsSubtlePanelFillColor)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .stroke(Color.white.opacity(0.06), lineWidth: 1)
+                    .stroke(settingsSubtlePanelStrokeColor, lineWidth: 1)
             )
             .contentShape(Rectangle())
         }
@@ -684,11 +810,11 @@ struct SettingsView: View {
         .padding(.vertical, 10)
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(Color.white.opacity(0.03))
+                .fill(settingsSubtlePanelFillColor)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .stroke(Color.white.opacity(0.06), lineWidth: 1)
+                .stroke(settingsSubtlePanelStrokeColor, lineWidth: 1)
         )
     }
 
@@ -786,14 +912,14 @@ struct SettingsView: View {
         case .general:
             settingsSingleSectionContent(
                 title: viewModel.localizedText("常规", "General"),
-                subtitle: viewModel.localizedText("设置语言、开机启动和基础应用行为。", "Configure language, launch at login, and basic app behavior.")
+                subtitle: viewModel.localizedText("设置语言、设置窗口外观、开机启动和基础应用行为。", "Configure language, settings window appearance, launch at login, and basic app behavior.")
             ) {
                 appBehaviorSection
             }
         case .menuBar:
             settingsSingleSectionContent(
                 title: viewModel.localizedText("菜单栏", "Menubar"),
-                subtitle: viewModel.localizedText("控制菜单栏显示模式、外观和信息密度。", "Control menubar display mode, appearance, and information density.")
+                subtitle: viewModel.localizedText("控制菜单栏显示哪些服务、如何展示以及信息密度。", "Control which services appear in the menubar, how they render, and information density.")
             ) {
                 menuBarPreferencesSection
             }
@@ -1037,7 +1163,7 @@ struct SettingsView: View {
         )
         .overlay(
             RoundedRectangle(cornerRadius: settingsSectionCornerRadius, style: .continuous)
-                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                .stroke(settingsShellStrokeColor, lineWidth: 1)
         )
     }
 
@@ -1144,9 +1270,12 @@ struct SettingsView: View {
             SettingsOverviewCardItem(
                 id: "menubar",
                 icon: "menubar.rectangle",
-                title: viewModel.localizedText("菜单栏模式", "Menubar Mode"),
+                title: viewModel.localizedText("界面与菜单栏", "Interface & Menubar"),
                 value: isMulti ? viewModel.localizedText("多模型", "Multi") : viewModel.localizedText("单模型", "Single"),
-                detail: "\(statusBarAppearanceModeSummary) · \(statusBarDisplayStyleSummary)",
+                detail: viewModel.localizedText(
+                    "设置窗口 \(statusBarAppearanceModeSummary) · 菜单栏 \(statusBarDisplayStyleSummary)",
+                    "Settings window \(statusBarAppearanceModeSummary) · Menubar \(statusBarDisplayStyleSummary)"
+                ),
                 accent: settingsAccentCyan
             )
         ]
@@ -1189,7 +1318,10 @@ struct SettingsView: View {
                 icon: "pin.circle",
                 title: viewModel.localizedText("菜单栏来源", "Menubar Sources"),
                 value: "\(statusBarSourceCount)",
-                detail: "\(statusBarAppearanceModeSummary) · \(statusBarDisplayStyleSummary)",
+                detail: viewModel.localizedText(
+                    "设置窗口 \(statusBarAppearanceModeSummary) · 菜单栏 \(statusBarDisplayStyleSummary)",
+                    "Settings window \(statusBarAppearanceModeSummary) · Menubar \(statusBarDisplayStyleSummary)"
+                ),
                 accent: settingsAccentCyan
             )
         ]
@@ -1421,6 +1553,10 @@ struct SettingsView: View {
 
     private func settingsTabButton(_ tab: SettingsTab) -> some View {
         let isSelected = selectedSettingsTab == tab
+        let selectedTextColor = settingsUsesLightAppearance ? settingsAccentBlue : Color.black
+        let idleTextColor = settingsBodyColor
+        let selectedFillColor = settingsUsesLightAppearance ? settingsAccentBlue.opacity(0.14) : Color.white.opacity(0.8)
+        let idleFillColor = settingsUsesLightAppearance ? Color.black.opacity(0.04) : Color.white.opacity(0.15)
 
         return Button {
             selectedSettingsTab = tab
@@ -1433,13 +1569,13 @@ struct SettingsView: View {
             Text(settingsTabTitle(tab))
                 // tab 文字字号与选中态字重。
                 .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
-                .foregroundStyle(isSelected ? Color.black : Color.white.opacity(0.80))
+                .foregroundStyle(isSelected ? selectedTextColor : idleTextColor)
                 .padding(.horizontal, 12)
                 .frame(height: 28)
                 .background(
                     // tab 背景：选中是亮底，未选中是 white_15。
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
-                        .fill(isSelected ? Color.white.opacity(0.8) : Color.white.opacity(0.15))
+                        .fill(isSelected ? selectedFillColor : idleFillColor)
                 )
                 .contentShape(Rectangle())
         }
@@ -1620,7 +1756,7 @@ struct SettingsView: View {
         appliesTintToBundledImage: Bool = false
     ) -> some View {
         if let image = bundledImage(named: name) {
-            if appliesTintToBundledImage {
+            if appliesTintToBundledImage || settingsUsesLightAppearance {
                 // 图标按原始宽高比缩放，避免不同视觉比例被拉伸。
                 Image(nsImage: image)
                     .renderingMode(.template)
@@ -1894,11 +2030,11 @@ struct SettingsView: View {
         .frame(height: 38)
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(isSelected ? Color.white.opacity(0.30) : Color.clear)
+                .fill(isSelected ? settingsSelectedRowFillColor : Color.clear)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(isSelected ? Color.white.opacity(0.80) : Color.white.opacity(0.30), lineWidth: 1)
+                .stroke(isSelected ? settingsSelectedRowStrokeColor : settingsRowStrokeColor, lineWidth: 1)
         )
         .overlay(alignment: dropTargetInsertAfter ? .bottom : .top) {
             if provider.enabled,
@@ -1906,7 +2042,7 @@ struct SettingsView: View {
                draggingProviderID != provider.id,
                dropTargetProviderID == provider.id {
                 Rectangle()
-                    .fill(Color.white.opacity(0.90))
+                    .fill(settingsDropIndicatorColor)
                     .frame(height: 2)
                     .padding(.horizontal, 8)
             }
@@ -1923,7 +2059,7 @@ struct SettingsView: View {
     private func reorderHandle() -> some View {
         Image(systemName: "line.3.horizontal")
             .font(.system(size: 11, weight: .semibold))
-            .foregroundStyle(Color.white.opacity(0.50))
+            .foregroundStyle(settingsHintColor)
             .frame(width: 14, height: 14)
             .contentShape(Rectangle())
     }
@@ -2100,6 +2236,11 @@ struct SettingsView: View {
             Spacer()
                 .frame(height: 24)
 
+            settingsAppearanceModeSection
+
+            Spacer()
+                .frame(height: 24)
+
             VStack(alignment: .leading, spacing: 8) {
                 let launchAtLoginBinding = Binding(
                     get: { viewModel.launchAtLoginEnabled },
@@ -2136,11 +2277,6 @@ struct SettingsView: View {
     private var menuBarPreferencesSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             statusBarMultiUsageSection
-
-            Spacer()
-                .frame(height: 24)
-
-            statusBarAppearanceModeSection
 
             Spacer()
                 .frame(height: 24)
@@ -2226,15 +2362,15 @@ struct SettingsView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var statusBarAppearanceModeSection: some View {
+    private var settingsAppearanceModeSection: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 12) {
-                Text(settingsStatusBarAppearanceModeTitle)
+                Text(settingsAppearanceModeTitle)
                     .font(settingsLabelFont)
                     .foregroundStyle(settingsBodyColor)
                     .frame(width: 48, alignment: .leading)
 
-                statusBarAppearanceModeSegmentControl
+                settingsAppearanceModeSegmentControl
 
                 Spacer(minLength: 0)
             }
@@ -2243,7 +2379,7 @@ struct SettingsView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 
-    private var statusBarAppearanceModeSegmentControl: some View {
+    private var settingsAppearanceModeSegmentControl: some View {
         Picker("", selection: Binding(
             get: { viewModel.statusBarAppearanceMode.id },
             set: { newValue in
@@ -2252,9 +2388,9 @@ struct SettingsView: View {
                 }
             }
         )) {
-            Text(settingsStatusBarAppearanceFollowWallpaper).tag(StatusBarAppearanceMode.followWallpaper.id)
-            Text(settingsStatusBarAppearanceDark).tag(StatusBarAppearanceMode.dark.id)
-            Text(settingsStatusBarAppearanceLight).tag(StatusBarAppearanceMode.light.id)
+            Text(settingsAppearanceFollowWallpaper).tag(StatusBarAppearanceMode.followWallpaper.id)
+            Text(settingsAppearanceDark).tag(StatusBarAppearanceMode.dark.id)
+            Text(settingsAppearanceLight).tag(StatusBarAppearanceMode.light.id)
         }
         .pickerStyle(.segmented)
         .controlSize(.small)
@@ -2298,14 +2434,14 @@ struct SettingsView: View {
         ]
         return ZStack(alignment: .leading) {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color.black)
+                .fill(settingsUsesLightAppearance ? Color(hex: 0xF4F5F7) : Color.black)
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color.white.opacity(0.30), lineWidth: 1)
+                .stroke(settingsRowStrokeColor, lineWidth: 1)
 
             HStack(spacing: 16) {
                 ForEach(Array(items.enumerated()), id: \.offset) { _, item in
                     HStack(spacing: 4) {
-                        if let image = bundledImage(named: item.icon) {
+                        if let image = themedBundledImage(named: item.icon) {
                             Image(nsImage: image)
                                 .resizable()
                                 .scaledToFit()
@@ -2314,7 +2450,7 @@ struct SettingsView: View {
                         }
                         Text(item.value)
                             .font(.system(size: 12, weight: .semibold))
-                            .foregroundStyle(Color.white.opacity(0.8))
+                            .foregroundStyle(settingsBodyColor)
                             .fixedSize(horizontal: true, vertical: false)
                     }
                     .fixedSize(horizontal: true, vertical: false)
@@ -2337,30 +2473,30 @@ struct SettingsView: View {
         ]
         return ZStack(alignment: .leading) {
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color.black)
+                .fill(settingsUsesLightAppearance ? Color(hex: 0xF4F5F7) : Color.black)
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .stroke(Color.white.opacity(0.30), lineWidth: 1)
+                .stroke(settingsRowStrokeColor, lineWidth: 1)
 
             HStack(spacing: 16) {
                 ForEach(Array(items.enumerated()), id: \.offset) { _, item in
                     HStack(spacing: 4) {
                         ZStack(alignment: .bottom) {
                             RoundedRectangle(cornerRadius: 3, style: .continuous)
-                                .fill(Color.white.opacity(0.30))
+                                .fill(settingsQuotaTrackColor)
                                 .frame(width: 10, height: 20)
                             RoundedRectangle(cornerRadius: 2, style: .continuous)
-                                .fill(Color.white.opacity(0.8))
+                                .fill(settingsUsesLightAppearance ? Color.black.opacity(0.72) : Color.white.opacity(0.8))
                                 .frame(width: 6, height: max(0, round(16 * item.percent / 100)))
                                 .offset(y: -2)
                         }
                         VStack(alignment: .leading, spacing: 0) {
                             Text(item.name)
                                 .font(.system(size: 10, weight: .regular))
-                                .foregroundStyle(Color.white.opacity(0.80))
+                                .foregroundStyle(settingsHintColor)
                                 .lineLimit(1)
                             Text(item.value)
                                 .font(.system(size: 10, weight: .semibold))
-                                .foregroundStyle(Color.white.opacity(0.8))
+                                .foregroundStyle(settingsBodyColor)
                                 .lineLimit(1)
                         }
                         .offset(y: 1)
@@ -2782,19 +2918,19 @@ struct SettingsView: View {
         viewModel.text(.statusBarDisplayStyle)
     }
 
-    private var settingsStatusBarAppearanceModeTitle: String {
+    private var settingsAppearanceModeTitle: String {
         viewModel.text(.statusBarAppearanceMode)
     }
 
-    private var settingsStatusBarAppearanceFollowWallpaper: String {
+    private var settingsAppearanceFollowWallpaper: String {
         viewModel.text(.statusBarAppearanceFollowWallpaper)
     }
 
-    private var settingsStatusBarAppearanceDark: String {
+    private var settingsAppearanceDark: String {
         viewModel.text(.statusBarAppearanceDark)
     }
 
-    private var settingsStatusBarAppearanceLight: String {
+    private var settingsAppearanceLight: String {
         viewModel.text(.statusBarAppearanceLight)
     }
 
@@ -2991,12 +3127,12 @@ struct SettingsView: View {
 
             if let provider {
                 providerIcon(for: provider, size: 12)
-            } else if let image = bundledImage(named: relayPresetIconName(for: preset)) {
+            } else if let image = themedBundledImage(named: relayPresetIconName(for: preset)) {
                 Image(nsImage: image)
                     .resizable()
                     .scaledToFit()
                     .frame(width: 12, height: 12)
-            } else if let image = bundledImage(named: "relay_icon") {
+            } else if let image = themedBundledImage(named: "relay_icon") {
                 Image(nsImage: image)
                     .resizable()
                     .scaledToFit()
@@ -3006,7 +3142,7 @@ struct SettingsView: View {
                     .resizable()
                     .scaledToFit()
                     .frame(width: 12, height: 12)
-                    .foregroundStyle(.primary)
+                    .foregroundStyle(settingsBodyColor)
             }
 
             Text(preset.displayName)
@@ -3019,11 +3155,11 @@ struct SettingsView: View {
         .frame(height: 38)
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(isSelected ? Color.white.opacity(0.30) : Color.clear)
+                .fill(isSelected ? settingsSelectedRowFillColor : Color.clear)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(isSelected ? Color.white.opacity(0.80) : Color.white.opacity(0.30), lineWidth: 1)
+                .stroke(isSelected ? settingsSelectedRowStrokeColor : settingsRowStrokeColor, lineWidth: 1)
         )
         .contentShape(Rectangle())
         .onTapGesture {
@@ -3169,7 +3305,7 @@ struct SettingsView: View {
                 in: 0...100
             )
             .frame(width: 200)
-            .tint(Color.white.opacity(0.80))
+            .tint(settingsSliderTintColor)
 
             officialThresholdStepper(provider)
         }
@@ -3337,7 +3473,7 @@ struct SettingsView: View {
                 in: 0...100
             )
             .frame(width: 200)
-            .tint(Color.white.opacity(0.80))
+            .tint(settingsSliderTintColor)
 
             officialThresholdStepper(provider)
         }
@@ -4132,7 +4268,7 @@ struct SettingsView: View {
                         : minBarHeight
 
                     Capsule()
-                        .fill(value > 0 ? Color.white.opacity(0.62) : Color.white.opacity(0.22))
+                        .fill(value > 0 ? settingsTrendPrimaryColor : settingsTrendMutedColor)
                         .frame(width: barWidth, height: barHeight)
                 }
             }
@@ -4164,7 +4300,7 @@ struct SettingsView: View {
             }
             .frame(height: 14)
             .font(.system(size: 10, weight: .regular))
-            .foregroundStyle(Color.white.opacity(0.45))
+            .foregroundStyle(settingsHintColor)
         } else {
             Color.clear
                 .frame(height: 14)
@@ -4197,9 +4333,9 @@ struct SettingsView: View {
 
             HStack(spacing: 0) {
                 ForEach(displayPoints) { point in
-                    Text(localUsageWeeklyLabel(point.startAt))
-                        .font(.system(size: 10, weight: .regular))
-                        .foregroundStyle(Color.white.opacity(0.45))
+                        Text(localUsageWeeklyLabel(point.startAt))
+                            .font(.system(size: 10, weight: .regular))
+                            .foregroundStyle(settingsHintColor)
                         .frame(maxWidth: .infinity)
                 }
             }
@@ -4249,7 +4385,7 @@ struct SettingsView: View {
                     }
                 }
                 .stroke(
-                    Color.white.opacity(0.62),
+                    settingsTrendPrimaryColor,
                     style: StrokeStyle(lineWidth: 2, lineCap: .round, lineJoin: .round)
                 )
             }
@@ -4340,7 +4476,7 @@ struct SettingsView: View {
         .frame(height: 24)
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(Color.white.opacity(0.30), lineWidth: 1)
+                .stroke(settingsRowStrokeColor, lineWidth: 1)
         )
     }
 
@@ -4349,17 +4485,17 @@ struct SettingsView: View {
         HStack(spacing: 4) {
             Text(label)
                 .font(.system(size: 10, weight: .regular))
-                .foregroundStyle(Color.white.opacity(0.40))
+                .foregroundStyle(settingsHintColor)
 
             Text(LocalTrendValueFormatter.metricValueText(value: period.totalTokens, metric: .tokens, language: viewModel.language))
                 .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(Color.white.opacity(0.80))
+                .foregroundStyle(settingsBodyColor)
 
             localUsageTrendSummaryDivider
 
             Text(localUsageTrendResponseText(period.responses))
                 .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle(Color.white.opacity(0.80))
+                .foregroundStyle(settingsBodyColor)
         }
         .lineLimit(1)
         .minimumScaleFactor(0.85)
@@ -4368,7 +4504,7 @@ struct SettingsView: View {
 
     private var localUsageTrendSummaryDivider: some View {
         RoundedRectangle(cornerRadius: 4, style: .continuous)
-            .fill(Color.white.opacity(0.30))
+            .fill(settingsRowStrokeColor)
             .frame(width: 1, height: 8)
     }
 
@@ -4412,7 +4548,7 @@ struct SettingsView: View {
         if loading {
             return LocalUsageTrendChartStatus(
                 text: viewModel.localizedText("加载中...", "Loading..."),
-                color: Color.white.opacity(0.30)
+                color: settingsMutedHintColor
             )
         }
         if let error, !error.isEmpty {
@@ -4433,12 +4569,12 @@ struct SettingsView: View {
                     )
                     return LocalUsageTrendChartStatus(
                         text: text,
-                        color: Color.white.opacity(0.30)
+                        color: settingsMutedHintColor
                     )
                 }
                 return LocalUsageTrendChartStatus(
                     text: viewModel.localizedText("当前账号暂无可归属事件", "No attributable events for current account"),
-                    color: Color.white.opacity(0.30)
+                    color: settingsMutedHintColor
                 )
             }
             let noDataText = provider.type == .gemini
@@ -4446,7 +4582,7 @@ struct SettingsView: View {
                 : viewModel.localizedText("暂无数据", "No data")
             return LocalUsageTrendChartStatus(
                 text: noDataText,
-                color: Color.white.opacity(0.30)
+                color: settingsMutedHintColor
             )
         }
         return nil
@@ -4489,7 +4625,7 @@ struct SettingsView: View {
             HStack(spacing: 8) {
                 Text(selectorText)
                     .font(.system(size: 12, weight: .regular))
-                    .foregroundStyle(Color.white.opacity(0.80))
+                    .foregroundStyle(settingsBodyColor)
                     .lineLimit(1)
                     .truncationMode(.tail)
 
@@ -4497,7 +4633,7 @@ struct SettingsView: View {
 
                 Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                     .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(Color.white.opacity(0.80))
+                    .foregroundStyle(settingsHintColor)
                     .frame(width: 14, height: 14, alignment: .center)
             }
             .padding(.leading, 12)
@@ -4505,11 +4641,11 @@ struct SettingsView: View {
             .frame(maxWidth: .infinity, minHeight: 24, maxHeight: 24)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color(hex: 0x2A2B2F))
+                    .fill(settingsControlFillColor)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(Color.white.opacity(0.12), lineWidth: 1)
+                    .stroke(settingsControlStrokeColor, lineWidth: 1)
             )
             .contentShape(Rectangle())
         }
@@ -4555,14 +4691,14 @@ struct SettingsView: View {
                     HStack(spacing: 8) {
                         Text(option.label)
                             .font(.system(size: 12, weight: option.id == selectedID ? .semibold : .regular))
-                            .foregroundStyle(Color.white.opacity(option.id == selectedID ? 0.90 : 0.78))
+                            .foregroundStyle(option.id == selectedID ? settingsTitleColor : settingsBodyColor)
                             .lineLimit(1)
                             .truncationMode(.middle)
                         Spacer(minLength: 8)
                         if option.id == selectedID {
                             Image(systemName: "checkmark")
                                 .font(.system(size: 11, weight: .semibold))
-                                .foregroundStyle(Color.white.opacity(0.85))
+                                .foregroundStyle(settingsAccentBlue)
                         }
                     }
                     .padding(.horizontal, 10)
@@ -4570,7 +4706,7 @@ struct SettingsView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(
                         RoundedRectangle(cornerRadius: 6, style: .continuous)
-                            .fill(option.id == selectedID ? Color.white.opacity(0.12) : Color.clear)
+                            .fill(option.id == selectedID ? settingsPopoverSelectedFillColor : Color.clear)
                     )
                     .contentShape(Rectangle())
                 }
@@ -4581,11 +4717,11 @@ struct SettingsView: View {
         .frame(width: 260, alignment: .leading)
         .background(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color(hex: 0x1F2024))
+                .fill(settingsPopoverFillColor)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(Color.white.opacity(0.12), lineWidth: 1)
+                .stroke(settingsControlStrokeColor, lineWidth: 1)
         )
     }
 
@@ -5245,7 +5381,7 @@ struct SettingsView: View {
 
             if let planType, !planType.isEmpty {
                 RoundedRectangle(cornerRadius: 4, style: .continuous)
-                    .fill(Color.white.opacity(0.40))
+                    .fill(settingsRowStrokeColor)
                     .frame(width: 1, height: 8)
 
                 Text(planType)
@@ -5253,8 +5389,8 @@ struct SettingsView: View {
                     .foregroundStyle(
                         LinearGradient(
                             colors: [
-                                Color.white.opacity(0.80),
-                                Color(red: 1.0, green: 0.819, blue: 0.225, opacity: 0.80)
+                                settingsUsesLightAppearance ? Color.black.opacity(0.82) : Color.white.opacity(0.80),
+                                Color(red: 1.0, green: 0.74, blue: 0.18, opacity: settingsUsesLightAppearance ? 0.95 : 0.80)
                             ],
                             startPoint: .leading,
                             endPoint: .trailing
@@ -6309,7 +6445,7 @@ struct SettingsView: View {
                     )
                     .overlay(
                         RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .stroke(Color.black.opacity(0.08), lineWidth: 1)
+                            .stroke(outlineColor, lineWidth: 1)
                     )
                 }
 
@@ -6341,7 +6477,7 @@ struct SettingsView: View {
                     )
                     .overlay(
                         RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .stroke(Color.black.opacity(0.08), lineWidth: 1)
+                            .stroke(outlineColor, lineWidth: 1)
                     )
                 }
 
@@ -6353,7 +6489,7 @@ struct SettingsView: View {
                         .padding(8)
                         .background(
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .fill(Color.white.opacity(0.08))
+                                .fill(settingsInputFillColor)
                         )
                         .overlay(
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
@@ -6530,7 +6666,7 @@ struct SettingsView: View {
             HStack(spacing: 6) {
                 Text(metric.title)
                     .font(.system(size: 10, weight: .regular))
-                    .foregroundStyle(Color.white.opacity(0.55))
+                    .foregroundStyle(settingsHintColor)
                     .lineSpacing(0)
                     .lineLimit(1)
 
@@ -6539,18 +6675,20 @@ struct SettingsView: View {
                 HStack(spacing: 2) {
                     if let image = bundledImage(named: "menu_reset_clock_icon") {
                         Image(nsImage: image)
+                            .renderingMode(.template)
                             .resizable()
                             .scaledToFit()
                             .frame(width: 10, height: 10)
+                            .foregroundStyle(settingsHintColor)
                     } else {
                         Image(systemName: "clock")
                             .font(.system(size: 10, weight: .regular))
-                            .foregroundStyle(Color.white.opacity(0.80))
+                            .foregroundStyle(settingsHintColor)
                     }
 
                     Text(metric.resetText)
                         .font(.system(size: 10, weight: .regular))
-                        .foregroundStyle(Color.white.opacity(0.40))
+                        .foregroundStyle(settingsMutedHintColor)
                         .monospacedDigit()
                         .lineSpacing(0)
                         .frame(minWidth: 42, alignment: .trailing)
@@ -6567,7 +6705,7 @@ struct SettingsView: View {
             HStack(spacing: 5) {
                 Text(metric.valueText)
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(Color.white.opacity(0.80))
+                    .foregroundStyle(settingsBodyColor)
                     .lineSpacing(0)
                     .frame(width: MetricValueLayoutFormatter.metricValueColumnWidth, alignment: .leading)
                     .lineLimit(1)
@@ -6575,7 +6713,7 @@ struct SettingsView: View {
                 GeometryReader { proxy in
                     ZStack(alignment: .leading) {
                         RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .fill(Color.white.opacity(0.30))
+                            .fill(settingsQuotaTrackColor)
                         if let percent = metric.percent, percent > 0 {
                             RoundedRectangle(cornerRadius: 8, style: .continuous)
                                 .fill(metric.barColor)
@@ -6606,7 +6744,7 @@ struct SettingsView: View {
 
     private func codexAccountIcon(size: CGFloat) -> some View {
         Group {
-            if let image = bundledImage(named: "menu_codex_icon") {
+            if let image = themedBundledImage(named: "menu_codex_icon") {
                 Image(nsImage: image)
                     .resizable()
                     .scaledToFit()
@@ -6622,7 +6760,7 @@ struct SettingsView: View {
 
     private func claudeAccountIcon(size: CGFloat) -> some View {
         Group {
-            if let image = bundledImage(named: "menu_claude_icon") {
+            if let image = themedBundledImage(named: "menu_claude_icon") {
                 Image(nsImage: image)
                     .resizable()
                     .scaledToFit()
@@ -6698,7 +6836,7 @@ struct SettingsView: View {
                     )
                     .overlay(
                         RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .stroke(Color.black.opacity(0.08), lineWidth: 1)
+                            .stroke(outlineColor, lineWidth: 1)
                     )
                 }
 
@@ -6709,7 +6847,7 @@ struct SettingsView: View {
                     .padding(8)
                     .background(
                         RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .fill(Color.white.opacity(0.08))
+                            .fill(settingsInputFillColor)
                     )
                     .overlay(
                         RoundedRectangle(cornerRadius: 8, style: .continuous)
@@ -8437,7 +8575,7 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func providerIcon(for provider: ProviderDescriptor, size: CGFloat) -> some View {
-        if let image = bundledImage(named: iconName(for: provider)) {
+        if let image = themedBundledImage(named: iconName(for: provider)) {
             Image(nsImage: image)
                 .resizable()
                 .scaledToFit()
@@ -8446,9 +8584,17 @@ struct SettingsView: View {
             Image(systemName: fallbackIcon(for: provider))
                 .resizable()
                 .scaledToFit()
-                .foregroundStyle(.primary)
+                .foregroundStyle(settingsBodyColor)
                 .frame(width: size, height: size)
         }
+    }
+
+    private func themedBundledImage(named name: String) -> NSImage? {
+        if settingsUsesLightAppearance,
+           let darkImage = bundledImage(named: "\(name)_dark") {
+            return darkImage
+        }
+        return bundledImage(named: name)
     }
 
     private func bundledImage(named name: String) -> NSImage? {
@@ -8825,7 +8971,7 @@ struct SettingsView: View {
         .padding(10)
         .background(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
-                .fill(Color.white.opacity(0.05))
+                .fill(settingsSubtlePanelFillColor)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 10, style: .continuous)
@@ -8862,7 +9008,7 @@ struct SettingsView: View {
                 providerIcon(for: provider, size: 12)
                 Text(sidebarDisplayName(for: provider))
                     .font(.system(size: 12, weight: .semibold))
-                    .foregroundStyle(Color.white)
+                    .foregroundStyle(settingsBodyColor)
                     .lineLimit(1)
                 Spacer(minLength: 8)
                 Text(summaryStatus.text)
@@ -8875,25 +9021,26 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: 6) {
                 Text(viewModel.text(.balanceLabel))
                     .font(.system(size: 10, weight: .regular))
-                    .foregroundStyle(Color.white)
+                    .foregroundStyle(settingsHintColor)
 
                 HStack(spacing: 6) {
                     if let image = bundledImage(named: "menu_balance_icon") {
                         Image(nsImage: image)
+                            .renderingMode(.template)
                             .resizable()
                             .scaledToFit()
                             .frame(width: 16, height: 16)
-                            .opacity(0.9)
+                            .foregroundStyle(settingsBodyColor)
                     } else {
                         Image(systemName: "dollarsign.circle.fill")
                             .resizable()
                             .scaledToFit()
                             .frame(width: 16, height: 16)
-                            .foregroundStyle(Color.white.opacity(0.9))
+                            .foregroundStyle(settingsBodyColor)
                     }
                     Text(balanceText)
                         .font(.system(size: 16, weight: .semibold))
-                        .foregroundStyle(Color.white)
+                        .foregroundStyle(settingsBodyColor)
                 }
             }
 
@@ -8930,7 +9077,7 @@ struct SettingsView: View {
         .padding(12)
         .background(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
-                .fill(Color.black)
+                .fill(cardBackground)
         )
         .overlay(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
@@ -9209,16 +9356,16 @@ private extension View {
     func relayCompactInput() -> some View {
         self
             .font(.system(size: 12, weight: .regular))
-            .foregroundStyle(Color.white.opacity(0.80))
+            .foregroundStyle(Color.primary.opacity(0.80))
             .padding(.horizontal, 8)
             .frame(height: 24)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.white.opacity(0.15))
+                    .fill(Color.primary.opacity(0.08))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(Color.black.opacity(0.08), lineWidth: 1)
+                    .stroke(Color.primary.opacity(0.10), lineWidth: 1)
             )
     }
 
@@ -9226,16 +9373,16 @@ private extension View {
         // Relay 基础输入框样式（与 token 输入框保持一致）。
         self
             .font(.system(size: 12, weight: .regular))
-            .foregroundStyle(Color.white.opacity(0.80))
+            .foregroundStyle(Color.primary.opacity(0.80))
             .padding(.horizontal, 8)
             .frame(height: 24)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.white.opacity(0.15))
+                    .fill(Color.primary.opacity(0.08))
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .stroke(Color.black.opacity(0.08), lineWidth: 1)
+                    .stroke(Color.primary.opacity(0.10), lineWidth: 1)
             )
     }
 }

--- a/Sources/AIPlanMonitor/UI/SettingsView.swift
+++ b/Sources/AIPlanMonitor/UI/SettingsView.swift
@@ -73,7 +73,7 @@ struct SettingsView: View {
     @State private var newProviderBaseURL = "https://"
     @State private var newProviderTemplateID = "generic-newapi"
     @State private var selectedRelayPresetID: String?
-    @State private var selectedSettingsTab: SettingsTab = .general
+    @State private var selectedSettingsTab: SettingsTab = .overview
     @State private var selectedGroup: ProviderGroup = .official
     @State private var selectedProviderID: String?
     @State private var settingsNow = Date()
@@ -101,6 +101,16 @@ struct SettingsView: View {
     private let outlineColor = Color.white.opacity(0.30)
     // 内层卡片/黑色内容容器圆角。
     private let cardCornerRadius: CGFloat = 8
+    private let settingsShellCornerRadius: CGFloat = 20
+    private let settingsSidebarCornerRadius: CGFloat = 20
+    private let settingsSectionCornerRadius: CGFloat = 8
+    private let settingsShellStrokeColor = Color.white.opacity(0.08)
+    private let settingsSidebarFillColor = Color.white.opacity(0.03)
+    private let settingsSectionFillColor = Color.white.opacity(0.04)
+    private let settingsAccentBlue = Color(hex: 0x168DFF)
+    private let settingsAccentGreen = Color(hex: 0x31D158)
+    private let settingsAccentPurple = Color(hex: 0xC93BFF)
+    private let settingsAccentCyan = Color(hex: 0x12D6F3)
     // 分割线颜色（与 15% 白描边风格一致）。
     private let dividerColor = Color.white.opacity(0.15)
     // 模型设置详情项垂直间距（设计稿统一 24px）。
@@ -173,10 +183,19 @@ struct SettingsView: View {
     }
 
     private enum SettingsTab: String, CaseIterable, Identifiable {
+        case overview
         case general
-        case models
+        case menuBar
+        case permissions
+        case localData
+        case officialProviders
+        case customProviders
 
         var id: String { rawValue }
+
+        var isProviderSection: Bool {
+            self == .officialProviders || self == .customProviders
+        }
     }
 
     private struct CodexProfileEditorState: Identifiable {
@@ -225,6 +244,15 @@ struct SettingsView: View {
     private struct LocalUsageTrendChartStatus {
         var text: String
         var color: Color
+    }
+
+    private struct SettingsOverviewCardItem: Identifiable {
+        var id: String
+        var icon: String
+        var title: String
+        var value: String
+        var detail: String
+        var accent: Color
     }
 
     var body: some View {
@@ -297,7 +325,12 @@ struct SettingsView: View {
             syncSelection()
         }
         .onChange(of: selectedSettingsTab) { _, newValue in
-            if newValue == .models {
+            if newValue == .officialProviders {
+                selectedGroup = .official
+            } else if newValue == .customProviders {
+                selectedGroup = .thirdParty
+            }
+            if newValue.isProviderSection {
                 viewModel.refreshSettingsProfileState()
             }
         }
@@ -380,58 +413,864 @@ struct SettingsView: View {
     private var settingsMainContent: some View {
         ZStack {
             panelBackground
+                .ignoresSafeArea()
 
-            VStack(alignment: .leading, spacing: 16) {
-                settingsTabBar
+            HStack(alignment: .top, spacing: 18) {
+                settingsNavigationSidebar
+                    .frame(width: 220)
+                    .frame(maxHeight: .infinity, alignment: .top)
 
-                Group {
-                    if selectedSettingsTab == .general {
-                        // 通用设置：内容在黑色圆角区域内滚动。
-                        ScrollView {
-                            topGeneralSection
-                                .padding(.top, 16)
-                                .padding(.horizontal, 16)
-                                .padding(.bottom, 24)
-                        }
-                        .scrollIndicators(.never)
-                        .background(
-                            RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous)
-                                .fill(cardBackground)
-                        )
-                        .clipShape(
-                            RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous)
-                        )
-                    } else {
-                        // 模型设置：外层一个黑色容器，内部左右分栏。
-                        HStack(spacing: 0) {
-                            sidebar
-                                .frame(width: 220)
-                                .frame(maxHeight: .infinity, alignment: .top)
-
-                            Rectangle()
-                                .fill(dividerColor)
-                                .frame(width: 1)
-
-                            detailPane
-                                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                                .padding(.horizontal, 16)
-                                .padding(.bottom, 16)
-                        }
-                        .background(
-                            RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous)
-                                .fill(cardBackground)
-                        )
-                        .clipShape(
-                            RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous)
-                        )
-                    }
+                VStack(alignment: .leading, spacing: 18) {
+                    settingsHeaderBar
+                    settingsContentPane
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 16)
-            // 预留标题栏高度，避免 tabs 与红绿灯重叠。
             .padding(.top, 44)
         }
+    }
+
+    private var settingsNavigationSidebar: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            HStack(spacing: 12) {
+                settingsSidebarIdentityIcon
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("AI Plan Monitor")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(settingsTitleColor)
+                    Text(viewModel.localizedText("监控与设置工作台", "Monitoring workspace"))
+                        .font(.system(size: 11, weight: .regular))
+                        .foregroundStyle(settingsHintColor)
+                }
+            }
+
+            Rectangle()
+                .fill(dividerColor)
+                .frame(height: 1)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 10) {
+                    settingsSidebarSectionTitle(viewModel.localizedText("工作台", "Workspace"))
+                    settingsSidebarTabButton(
+                        .overview,
+                        icon: "square.grid.2x2"
+                    )
+
+                    settingsSidebarSectionTitle(viewModel.localizedText("偏好", "Preferences"))
+                    settingsSidebarTabButton(
+                        .general,
+                        icon: "gearshape"
+                    )
+                    settingsSidebarTabButton(
+                        .menuBar,
+                        icon: "menubar.rectangle"
+                    )
+
+                    settingsSidebarSectionTitle(viewModel.localizedText("安全", "Security"))
+                    settingsSidebarTabButton(
+                        .permissions,
+                        icon: "lock.shield"
+                    )
+                    settingsSidebarTabButton(
+                        .localData,
+                        icon: "externaldrive"
+                    )
+
+                    settingsSidebarSectionTitle(viewModel.localizedText("服务", "Services"))
+                    settingsSidebarTabButton(
+                        .officialProviders,
+                        icon: "shippingbox"
+                    )
+                    settingsSidebarTabButton(
+                        .customProviders,
+                        icon: "point.3.connected.trianglepath.dotted"
+                    )
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .scrollIndicators(.never)
+
+            Spacer(minLength: 0)
+
+            VStack(alignment: .leading, spacing: 10) {
+                settingsSidebarVersionRow
+                settingsSidebarInfoRow(
+                    title: viewModel.localizedText("最近刷新", "Last refresh"),
+                    value: lastRefreshSummaryText
+                )
+                settingsSidebarGitHubLink
+            }
+        }
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: settingsSidebarCornerRadius, style: .continuous)
+                .fill(settingsSidebarFillColor)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: settingsSidebarCornerRadius, style: .continuous)
+                .stroke(settingsShellStrokeColor, lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private var settingsSidebarIdentityIcon: some View {
+        if let image = bundledImage(named: "app_icon_source") {
+            Image(nsImage: image)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 36, height: 36)
+                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        } else {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(settingsAccentBlue.opacity(0.18))
+                .frame(width: 36, height: 36)
+                .overlay(
+                    Image(systemName: "waveform.path.ecg")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(settingsAccentBlue)
+                )
+        }
+    }
+
+    private func settingsSidebarSectionTitle(_ title: String) -> some View {
+        Text(title)
+            .font(.system(size: 10, weight: .semibold))
+            .foregroundStyle(settingsHintColor.opacity(0.86))
+            .textCase(.uppercase)
+            .padding(.horizontal, 10)
+            .padding(.top, 8)
+    }
+
+    private func settingsSidebarTabButton(
+        _ tab: SettingsTab,
+        icon: String
+    ) -> some View {
+        let isSelected = selectedSettingsTab == tab
+
+        return Button {
+            selectedSettingsTab = tab
+            if tab == .officialProviders {
+                selectedGroup = .official
+            } else if tab == .customProviders {
+                selectedGroup = .thirdParty
+            }
+        } label: {
+            HStack(alignment: .center, spacing: 12) {
+                Image(systemName: icon)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(isSelected ? Color.white : settingsHintColor)
+                    .frame(width: 16, height: 16)
+
+                Text(settingsTabTitle(tab))
+                    .font(.system(size: 13, weight: isSelected ? .semibold : .regular))
+                    .foregroundStyle(isSelected ? Color.white : settingsTitleColor)
+                    .lineLimit(1)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 10)
+            .frame(height: 34)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(isSelected ? settingsAccentBlue : Color.clear)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(isSelected ? Color.white.opacity(0.08) : Color.clear, lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var settingsSidebarVersionRow: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(viewModel.localizedText("当前版本", "Current version"))
+                .font(.system(size: 11, weight: .regular))
+                .foregroundStyle(settingsHintColor)
+
+            HStack(alignment: .center, spacing: 8) {
+                Text(viewModel.currentAppVersion)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(settingsTitleColor)
+                    .lineLimit(1)
+
+                Spacer(minLength: 8)
+
+                Button {
+                    viewModel.checkForAppUpdate(force: true)
+                } label: {
+                    Text(viewModel.localizedText("检查更新", "Check Updates"))
+                        .font(.system(size: 13, weight: .semibold))
+                        .lineLimit(1)
+                }
+                .buttonStyle(.borderless)
+                .controlSize(.small)
+                .disabled(settingsUpdateActionDisabled)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.white.opacity(0.03))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.white.opacity(0.06), lineWidth: 1)
+        )
+    }
+
+    private var settingsSidebarGitHubLink: some View {
+        Button {
+            viewModel.openRepositoryPage()
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "arrow.up.right.square")
+                    .font(.system(size: 13, weight: .semibold))
+                    .frame(width: 16, height: 16)
+
+                Text("GitHub")
+                    .font(.system(size: 13, weight: .semibold))
+                    .lineLimit(1)
+
+                Spacer(minLength: 8)
+
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(settingsHintColor)
+            }
+            .foregroundStyle(settingsTitleColor)
+            .padding(.horizontal, 12)
+            .frame(height: 38)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color.white.opacity(0.03))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(Color.white.opacity(0.06), lineWidth: 1)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.borderless)
+        .controlSize(.small)
+    }
+
+    private var settingsUpdateActionDisabled: Bool {
+        viewModel.updateCheckInFlight ||
+        viewModel.updateDownloadInFlight ||
+        viewModel.updateInstallBufferingInFlight ||
+        viewModel.updateInstallationInFlight
+    }
+
+    private func settingsSidebarInfoRow(title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.system(size: 11, weight: .regular))
+                .foregroundStyle(settingsHintColor)
+            Text(value)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(settingsTitleColor)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(Color.white.opacity(0.03))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(Color.white.opacity(0.06), lineWidth: 1)
+        )
+    }
+
+    private var settingsHeaderBar: some View {
+        HStack(alignment: .top, spacing: 16) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(settingsHeaderTitle)
+                    .font(.system(size: 30, weight: .bold))
+                    .foregroundStyle(settingsTitleColor)
+
+                Text(settingsHeaderSubtitle)
+                    .font(.system(size: 13, weight: .regular))
+                    .foregroundStyle(settingsHintColor)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 12)
+
+            settingsRefreshAllButton
+        }
+    }
+
+    private var settingsRefreshAllButton: some View {
+        Button {
+            viewModel.refreshNow()
+        } label: {
+            Label(viewModel.localizedText("刷新全部", "Refresh All"), systemImage: "arrow.clockwise")
+                .font(.system(size: 13, weight: .semibold))
+                .labelStyle(.titleAndIcon)
+                .frame(minWidth: 104)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .tint(settingsAccentBlue)
+        .help(viewModel.localizedText("立即刷新所有已启用服务", "Refresh all enabled services now"))
+    }
+
+    @ViewBuilder
+    private var settingsHeaderUpdatePill: some View {
+        if let statusText = viewModel.settingsUpdateDisplayState.statusText {
+            let state = viewModel.settingsUpdateDisplayState
+            let statusTone: AppViewModel.UpdateDisplayTone = {
+                if case .checkFailed = state.kind {
+                    return .neutral
+                }
+                return state.tone
+            }()
+
+            settingsHeaderPill(
+                title: state.retryTitle.map { "\(statusText) · \($0)" } ?? statusText,
+                icon: "sparkles",
+                tint: settingsTopUpdateStatusColor(for: statusTone),
+                fill: settingsTopUpdateStatusColor(for: statusTone).opacity(0.10)
+            ) {
+                if case .updateAvailable = state.kind {
+                    viewModel.openLatestReleaseDownload()
+                } else if state.retryTitle != nil {
+                    viewModel.openLatestReleaseDownload()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func settingsHeaderPill(
+        title: String,
+        icon: String,
+        tint: Color,
+        fill: Color,
+        action: (() -> Void)? = nil
+    ) -> some View {
+        let label = Label(title, systemImage: icon)
+            .font(.system(size: 12, weight: .semibold))
+            .labelStyle(.titleAndIcon)
+            .lineLimit(1)
+
+        if let action {
+            Button(action: action) {
+                label
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.regular)
+            .tint(tint)
+        } else {
+            label
+                .foregroundStyle(tint)
+        }
+    }
+
+    @ViewBuilder
+    private var settingsContentPane: some View {
+        switch selectedSettingsTab {
+        case .overview:
+            overviewDashboardContent
+        case .general:
+            settingsSingleSectionContent(
+                title: viewModel.localizedText("常规", "General"),
+                subtitle: viewModel.localizedText("设置语言、开机启动和基础应用行为。", "Configure language, launch at login, and basic app behavior.")
+            ) {
+                appBehaviorSection
+            }
+        case .menuBar:
+            settingsSingleSectionContent(
+                title: viewModel.localizedText("菜单栏", "Menubar"),
+                subtitle: viewModel.localizedText("控制菜单栏显示模式、外观和信息密度。", "Control menubar display mode, appearance, and information density.")
+            ) {
+                menuBarPreferencesSection
+            }
+        case .permissions:
+            settingsSingleSectionContent(
+                title: viewModel.localizedText("权限", "Permissions"),
+                subtitle: viewModel.localizedText("管理通知、钥匙串和全盘访问授权。", "Manage notifications, keychain, and full disk access.")
+            ) {
+                permissionAccessSection
+            }
+        case .localData:
+            settingsSingleSectionContent(
+                title: viewModel.localizedText("本地数据", "Local Data"),
+                subtitle: viewModel.localizedText("扫描本机账号配置，或重置 AI Plan Monitor 的本地数据。", "Discover local account config or reset AI Plan Monitor's local data.")
+            ) {
+                localDataManagementSection
+            }
+        case .officialProviders:
+            providerDashboardContent(group: .official)
+        case .customProviders:
+            providerDashboardContent(group: .thirdParty)
+        }
+    }
+
+    private var overviewDashboardContent: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                settingsOverviewGrid(items: generalOverviewItems)
+                officialUsageTrendsOverviewSection
+            }
+            .padding(20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .scrollIndicators(.never)
+        .background(
+            RoundedRectangle(cornerRadius: settingsShellCornerRadius, style: .continuous)
+                .fill(cardBackground)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: settingsShellCornerRadius, style: .continuous)
+                .stroke(settingsShellStrokeColor, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: settingsShellCornerRadius, style: .continuous))
+    }
+
+    private func settingsSingleSectionContent<Content: View>(
+        title: String,
+        subtitle: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                settingsSectionCard(title: title, subtitle: subtitle) {
+                    content()
+                }
+            }
+            .padding(20)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .scrollIndicators(.never)
+        .background(
+            RoundedRectangle(cornerRadius: settingsShellCornerRadius, style: .continuous)
+                .fill(cardBackground)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: settingsShellCornerRadius, style: .continuous)
+                .stroke(settingsShellStrokeColor, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: settingsShellCornerRadius, style: .continuous))
+    }
+
+    private func providerDashboardContent(group: ProviderGroup) -> some View {
+        HStack(alignment: .top, spacing: 16) {
+            settingsSectionPanel {
+                providerSidebarContent(for: group)
+            }
+            .frame(width: 280)
+            .frame(maxHeight: .infinity, alignment: .top)
+
+            settingsSectionPanel {
+                detailPane
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .padding(20)
+        .background(
+            RoundedRectangle(cornerRadius: settingsShellCornerRadius, style: .continuous)
+                .fill(cardBackground)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: settingsShellCornerRadius, style: .continuous)
+                .stroke(settingsShellStrokeColor, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: settingsShellCornerRadius, style: .continuous))
+        .onAppear {
+            selectedGroup = group
+        }
+    }
+
+    @ViewBuilder
+    private func providerSidebarContent(for group: ProviderGroup) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(group == .official
+                ? viewModel.localizedText("官方服务", "Official Services")
+                : viewModel.localizedText("自定义接口", "Custom Endpoints"))
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundStyle(settingsTitleColor)
+
+            Group {
+                if group == .official {
+                    officialSidebarContent
+                } else {
+                    thirdPartySidebarContent
+                }
+            }
+        }
+    }
+
+    private func settingsOverviewGrid(items: [SettingsOverviewCardItem]) -> some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 180, maximum: 240), spacing: 16, alignment: .top)],
+            alignment: .leading,
+            spacing: 16
+        ) {
+            ForEach(items) { item in
+                settingsOverviewCard(item)
+            }
+        }
+    }
+
+    private func settingsOverviewCard(_ item: SettingsOverviewCardItem) -> some View {
+        VStack(alignment: .leading, spacing: 22) {
+            HStack(alignment: .top) {
+                Image(systemName: item.icon)
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(item.accent)
+
+                Spacer(minLength: 12)
+
+                Text(item.value)
+                    .font(.system(size: 24, weight: .bold))
+                    .foregroundStyle(item.accent)
+                    .multilineTextAlignment(.trailing)
+                    .lineLimit(2)
+                    .minimumScaleFactor(0.7)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text(item.title)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(settingsTitleColor)
+                Text(item.detail)
+                    .font(.system(size: 12, weight: .regular))
+                    .foregroundStyle(settingsHintColor)
+                    .lineSpacing(3)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, minHeight: 148, alignment: .topLeading)
+        .background(
+            RoundedRectangle(cornerRadius: settingsSectionCornerRadius, style: .continuous)
+                .fill(item.accent.opacity(0.12))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: settingsSectionCornerRadius, style: .continuous)
+                .stroke(item.accent.opacity(0.35), lineWidth: 1)
+        )
+    }
+
+    @ViewBuilder
+    private var officialUsageTrendsOverviewSection: some View {
+        let providers = officialUsageTrendOverviewProviders
+
+        if !providers.isEmpty {
+            VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(viewModel.localizedText("官方服务使用趋势", "Official Usage Trends"))
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(settingsTitleColor)
+
+                    Text(viewModel.localizedText(
+                        "仅汇总已启用的官方服务，本地趋势不等同于官方剩余额度。",
+                        "Only enabled official services are shown. Local trends are not the same as official remaining quota."
+                    ))
+                    .font(.system(size: 12, weight: .regular))
+                    .foregroundStyle(settingsHintColor)
+                    .lineSpacing(3)
+                    .fixedSize(horizontal: false, vertical: true)
+                }
+
+                ForEach(providers) { provider in
+                    settingsSectionPanel {
+                        officialLocalTrendSection(
+                            provider: provider,
+                            snapshot: viewModel.snapshots[provider.id],
+                            showsDivider: false,
+                            title: officialUsageTrendOverviewTitle(for: provider)
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private func settingsSectionCard<Content: View>(
+        title: String,
+        subtitle: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        settingsSectionPanel {
+            VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(title)
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(settingsTitleColor)
+                    Text(subtitle)
+                        .font(.system(size: 12, weight: .regular))
+                        .foregroundStyle(settingsHintColor)
+                        .lineSpacing(3)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                content()
+            }
+        }
+    }
+
+    private func settingsSectionPanel<Content: View>(
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .padding(18)
+        .background(
+            RoundedRectangle(cornerRadius: settingsSectionCornerRadius, style: .continuous)
+                .fill(settingsSectionFillColor)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: settingsSectionCornerRadius, style: .continuous)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
+    }
+
+    private var settingsHeaderTitle: String {
+        switch selectedSettingsTab {
+        case .overview:
+            return viewModel.localizedText("设置概览", "Settings Overview")
+        case .general:
+            return viewModel.localizedText("常规", "General")
+        case .menuBar:
+            return viewModel.localizedText("菜单栏", "Menubar")
+        case .permissions:
+            return viewModel.localizedText("权限", "Permissions")
+        case .localData:
+            return viewModel.localizedText("本地数据", "Local Data")
+        case .officialProviders:
+            return viewModel.localizedText("官方服务", "Official Services")
+        case .customProviders:
+            return viewModel.localizedText("自定义接口", "Custom Endpoints")
+        }
+    }
+
+    private var settingsHeaderSubtitle: String {
+        switch selectedSettingsTab {
+        case .overview:
+            return viewModel.localizedText(
+                "把监控、权限和服务配置收拢成一个可快速扫描的工作台。",
+                "A scannable workspace for monitoring, permissions, and service configuration."
+            )
+        case .general:
+            return viewModel.localizedText(
+                "管理应用语言、启动行为和基础偏好。",
+                "Manage app language, launch behavior, and basic preferences."
+            )
+        case .menuBar:
+            return viewModel.localizedText(
+                "调整菜单栏里显示哪些模型、如何显示以及跟随哪种外观。",
+                "Adjust which models appear in the menubar, how they render, and which appearance mode they use."
+            )
+        case .permissions:
+            return viewModel.localizedText(
+                "检查授权状态，确保通知、钥匙串和本地读取能力可用。",
+                "Review authorization status for notifications, keychain, and local file access."
+            )
+        case .localData:
+            return viewModel.localizedText(
+                "发现本地 CLI 账号配置，或在需要时清理本地应用数据。",
+                "Discover local CLI account config or clear local app data when needed."
+            )
+        case .officialProviders:
+            return viewModel.localizedText(
+                "管理 Codex、Claude、Gemini、Cursor 等官方来源和账号。",
+                "Manage official sources and accounts such as Codex, Claude, Gemini, and Cursor."
+            )
+        case .customProviders:
+            return viewModel.localizedText(
+                "配置 Relay、New API 和第三方余额接口。",
+                "Configure Relay, New API, and third-party balance endpoints."
+            )
+        }
+    }
+
+    private var generalOverviewItems: [SettingsOverviewCardItem] {
+        let totalProviders = viewModel.config.providers.count
+        let enabledProviders = viewModel.config.providers.filter(\.enabled).count
+        let disabledProviders = totalProviders - enabledProviders
+        let requiredPermissions = settingsRequiredPermissionCount
+        let grantedPermissions = settingsGrantedPermissionCount
+        let isMulti = viewModel.statusBarMultiUsageEnabled
+
+        return [
+            SettingsOverviewCardItem(
+                id: "providers",
+                icon: "square.stack.3d.up",
+                title: viewModel.localizedText("已追踪服务", "Tracked Providers"),
+                value: "\(totalProviders)",
+                detail: viewModel.localizedText(
+                    "\(officialProviderCount) 个官方来源，\(thirdPartyProviderCount) 个自定义来源",
+                    "\(officialProviderCount) official sources, \(thirdPartyProviderCount) custom sources"
+                ),
+                accent: settingsAccentBlue
+            ),
+            SettingsOverviewCardItem(
+                id: "enabled",
+                icon: "bolt.heart",
+                title: viewModel.localizedText("活跃监控", "Active Monitors"),
+                value: "\(enabledProviders)",
+                detail: disabledProviders > 0
+                    ? viewModel.localizedText("还有 \(disabledProviders) 个已停用", "\(disabledProviders) currently disabled")
+                    : viewModel.localizedText("全部服务都已启用", "All services enabled"),
+                accent: settingsAccentGreen
+            ),
+            SettingsOverviewCardItem(
+                id: "permissions",
+                icon: "lock.shield",
+                title: viewModel.localizedText("权限状态", "Permissions"),
+                value: "\(grantedPermissions)/\(requiredPermissions)",
+                detail: viewModel.localizedText(
+                    "通知、钥匙串与全盘访问统一收纳",
+                    "Notifications, keychain, and full disk access in one place"
+                ),
+                accent: settingsAccentPurple
+            ),
+            SettingsOverviewCardItem(
+                id: "menubar",
+                icon: "menubar.rectangle",
+                title: viewModel.localizedText("菜单栏模式", "Menubar Mode"),
+                value: isMulti ? viewModel.localizedText("多模型", "Multi") : viewModel.localizedText("单模型", "Single"),
+                detail: "\(statusBarAppearanceModeSummary) · \(statusBarDisplayStyleSummary)",
+                accent: settingsAccentCyan
+            )
+        ]
+    }
+
+    private var modelOverviewItems: [SettingsOverviewCardItem] {
+        let totalProviders = viewModel.config.providers.count
+        let enabledProviders = viewModel.config.providers.filter(\.enabled).count
+
+        return [
+            SettingsOverviewCardItem(
+                id: "official-models",
+                icon: "shippingbox",
+                title: viewModel.localizedText("官方服务", "Official Services"),
+                value: "\(officialProviderCount)",
+                detail: viewModel.localizedText("内置来源与官方账号接入", "Built-in services and first-party accounts"),
+                accent: settingsAccentBlue
+            ),
+            SettingsOverviewCardItem(
+                id: "relay-models",
+                icon: "point.3.connected.trianglepath.dotted",
+                title: viewModel.localizedText("自定义来源", "Custom Sources"),
+                value: "\(thirdPartyProviderCount)",
+                detail: viewModel.localizedText("Relay / New API / 余额接口", "Relay, New API, and balance endpoints"),
+                accent: settingsAccentPurple
+            ),
+            SettingsOverviewCardItem(
+                id: "enabled-models",
+                icon: "checkmark.circle",
+                title: viewModel.localizedText("正在轮询", "Polling Now"),
+                value: "\(enabledProviders)",
+                detail: viewModel.localizedText(
+                    "共 \(totalProviders) 个来源，其中 \(totalProviders - enabledProviders) 个暂停",
+                    "\(totalProviders - enabledProviders) paused out of \(totalProviders) sources"
+                ),
+                accent: settingsAccentGreen
+            ),
+            SettingsOverviewCardItem(
+                id: "pinned-models",
+                icon: "pin.circle",
+                title: viewModel.localizedText("菜单栏来源", "Menubar Sources"),
+                value: "\(statusBarSourceCount)",
+                detail: "\(statusBarAppearanceModeSummary) · \(statusBarDisplayStyleSummary)",
+                accent: settingsAccentCyan
+            )
+        ]
+    }
+
+    private var officialProviderCount: Int {
+        viewModel.config.providers.filter { $0.family == .official }.count
+    }
+
+    private var officialUsageTrendOverviewProviders: [ProviderDescriptor] {
+        viewModel.config.providers.filter { provider in
+            provider.enabled && shouldShowOfficialLocalTrendCard(for: provider)
+        }
+    }
+
+    private func officialUsageTrendOverviewTitle(for provider: ProviderDescriptor) -> String {
+        let displayName = sidebarDisplayName(for: provider)
+        if viewModel.language == .zhHans {
+            return "\(displayName) 使用趋势"
+        }
+        return "\(displayName) Usage Trend"
+    }
+
+    private var thirdPartyProviderCount: Int {
+        viewModel.config.providers.filter { $0.family == .thirdParty }.count
+    }
+
+    private var settingsRequiredPermissionCount: Int {
+        var count = 2
+        if viewModel.fullDiskAccessRelevant || viewModel.fullDiskAccessRequested {
+            count += 1
+        }
+        return count
+    }
+
+    private var settingsGrantedPermissionCount: Int {
+        var count = 0
+        if viewModel.hasNotificationPermission {
+            count += 1
+        }
+        if viewModel.secureStorageReady {
+            count += 1
+        }
+        if (viewModel.fullDiskAccessRelevant || viewModel.fullDiskAccessRequested) && viewModel.fullDiskAccessGranted {
+            count += 1
+        }
+        return count
+    }
+
+    private var statusBarAppearanceModeSummary: String {
+        switch viewModel.statusBarAppearanceMode {
+        case .followWallpaper:
+            return viewModel.localizedText("跟随壁纸", "Adaptive")
+        case .dark:
+            return viewModel.localizedText("深色", "Dark")
+        case .light:
+            return viewModel.localizedText("浅色", "Light")
+        }
+    }
+
+    private var statusBarDisplayStyleSummary: String {
+        switch viewModel.statusBarDisplayStyle {
+        case .iconPercent:
+            return viewModel.localizedText("图标 + 百分比", "Icon + percent")
+        case .barNamePercent:
+            return viewModel.localizedText("柱状 + 名称", "Bar + name")
+        }
+    }
+
+    private var statusBarSourceCount: Int {
+        if viewModel.statusBarMultiUsageEnabled {
+            return max(1, viewModel.config.statusBarMultiProviderIDs.count)
+        }
+        return viewModel.config.statusBarProviderID == nil ? 0 : 1
+    }
+
+    private var lastRefreshSummaryText: String {
+        guard let lastUpdatedAt = viewModel.lastUpdatedAt else {
+            return viewModel.localizedText("尚未刷新", "Not refreshed yet")
+        }
+        return settingsElapsedText(from: lastUpdatedAt)
     }
 
     private var showsResetDataDialog: Bool {
@@ -558,23 +1397,23 @@ struct SettingsView: View {
         Button(action: action) {
             Text(title)
                 .font(.system(size: 12, weight: weight))
-                .foregroundStyle(foreground)
-                .lineSpacing(0)
-                .frame(width: 110, height: 32)
-                .background(
-                    Capsule(style: .continuous)
-                        .fill(background)
-                )
-                .contentShape(Rectangle())
+                .frame(width: 110)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.borderedProminent)
+        .controlSize(.regular)
+        .tint(background)
     }
 
     private var settingsTabBar: some View {
         // 顶部 tab + 右侧版本信息区域。
         HStack(spacing: 8) {
+            settingsTabButton(.overview)
             settingsTabButton(.general)
-            settingsTabButton(.models)
+            settingsTabButton(.menuBar)
+            settingsTabButton(.permissions)
+            settingsTabButton(.localData)
+            settingsTabButton(.officialProviders)
+            settingsTabButton(.customProviders)
             Spacer()
             settingsTopMetaBar
         }
@@ -585,6 +1424,11 @@ struct SettingsView: View {
 
         return Button {
             selectedSettingsTab = tab
+            if tab == .officialProviders {
+                selectedGroup = .official
+            } else if tab == .customProviders {
+                selectedGroup = .thirdParty
+            }
         } label: {
             Text(settingsTabTitle(tab))
                 // tab 文字字号与选中态字重。
@@ -604,10 +1448,20 @@ struct SettingsView: View {
 
     private func settingsTabTitle(_ tab: SettingsTab) -> String {
         switch tab {
+        case .overview:
+            return viewModel.localizedText("概览", "Overview")
         case .general:
             return viewModel.text(.settingsGeneralTab)
-        case .models:
-            return viewModel.text(.settingsModelsTab)
+        case .menuBar:
+            return viewModel.localizedText("菜单栏", "Menubar")
+        case .permissions:
+            return viewModel.localizedText("权限", "Permissions")
+        case .localData:
+            return viewModel.localizedText("本地数据", "Local Data")
+        case .officialProviders:
+            return viewModel.localizedText("官方服务", "Official")
+        case .customProviders:
+            return viewModel.localizedText("自定义接口", "Custom")
         }
     }
 
@@ -873,30 +1727,21 @@ struct SettingsView: View {
     }
 
     private var modelGroupSegmentControl: some View {
-        HStack(spacing: 8) {
-            modelGroupButton(.official)
-            modelGroupButton(.thirdParty)
+        Picker("", selection: Binding(
+            get: { selectedGroup.id },
+            set: { newValue in
+                if let group = ProviderGroup(rawValue: newValue) {
+                    selectedGroup = group
+                    selectedSettingsTab = group == .official ? .officialProviders : .customProviders
+                }
+            }
+        )) {
+            Text(viewModel.text(.officialTab)).tag(ProviderGroup.official.id)
+            Text(viewModel.text(.thirdPartyTab)).tag(ProviderGroup.thirdParty.id)
         }
+        .pickerStyle(.segmented)
+        .controlSize(.small)
         .frame(width: 188, height: 20)
-    }
-
-    private func modelGroupButton(_ group: ProviderGroup) -> some View {
-        let isSelected = selectedGroup == group
-        let title = group == .official ? viewModel.text(.officialTab) : viewModel.text(.thirdPartyTab)
-        return Button {
-            selectedGroup = group
-        } label: {
-            Text(title)
-                .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
-                .foregroundStyle(isSelected ? Color.black : Color.white.opacity(0.80))
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(isSelected ? Color.white.opacity(0.80) : Color.white.opacity(0.15))
-                )
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 
     private var thirdPartySidebarContent: some View {
@@ -986,16 +1831,11 @@ struct SettingsView: View {
         } label: {
             Text(viewModel.language == .zhHans ? "添加 NewAPI 站点" : "Add NewAPI Site")
                 .font(.system(size: 10, weight: .semibold))
-            .foregroundStyle(Color.white.opacity(0.55))
-            .frame(maxWidth: .infinity, alignment: .center)
-            .frame(height: 22)
-            .overlay(
-                RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .stroke(Color.white.opacity(0.30), lineWidth: 1)
-            )
-            .contentShape(Rectangle())
+                .frame(maxWidth: .infinity, alignment: .center)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .tint(settingsAccentBlue)
     }
 
     @ViewBuilder
@@ -1035,7 +1875,7 @@ struct SettingsView: View {
                     selectedProviderID = provider.id
                 }
             ))
-            .toggleStyle(SettingsModelCheckboxToggleStyle())
+            .toggleStyle(.checkbox)
             .labelsHidden()
 
             providerIcon(for: provider, size: 12)
@@ -1219,26 +2059,34 @@ struct SettingsView: View {
     @ViewBuilder
     private var detailPane: some View {
         if let selectedProvider {
-            // 右侧详情面板：滚动内容区。
             ScrollView {
                 VStack(alignment: .leading, spacing: 14) {
                     providerSettingsCard(selectedProvider)
                 }
+                .padding(.top, 4)
             }
             .scrollIndicators(.never)
         } else {
-            VStack {
+            VStack(spacing: 12) {
                 Spacer()
+                Image(systemName: "slider.horizontal.3")
+                    .font(.system(size: 28, weight: .semibold))
+                    .foregroundStyle(settingsHintColor)
                 Text(viewModel.text(.selectProviderHint))
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(settingsTitleColor)
+                Text(viewModel.localizedText("从左侧选择一个来源后，这里会显示完整配置。", "Choose a source on the left to inspect and edit its full configuration."))
+                    .font(.system(size: 12, weight: .regular))
+                    .foregroundStyle(settingsHintColor)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 320)
                 Spacer()
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 
-    private var topGeneralSection: some View {
-        // 通用设置主内容：语言、开机启动、权限卡片、扫描、本地重置。
+    private var appBehaviorSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 12) {
                 Text(settingsLanguageTitle)
@@ -1265,7 +2113,7 @@ struct SettingsView: View {
                         "",
                         isOn: launchAtLoginBinding
                     )
-                    .toggleStyle(FigmaSwitchToggleStyle())
+                    .toggleStyle(.switch)
                     .labelsHidden()
                     .allowsHitTesting(false)
                     Spacer(minLength: 0)
@@ -1282,10 +2130,11 @@ struct SettingsView: View {
                     .padding(.leading, 60)
                     .lineLimit(1)
             }
+        }
+    }
 
-            Spacer()
-                .frame(height: 24)
-
+    private var menuBarPreferencesSection: some View {
+        VStack(alignment: .leading, spacing: 0) {
             statusBarMultiUsageSection
 
             Spacer()
@@ -1297,10 +2146,20 @@ struct SettingsView: View {
                 .frame(height: 24)
 
             statusBarDisplayStyleSection
+        }
+    }
 
-            Spacer()
-                .frame(height: 24)
+    private var generalBasicsSection: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            appBehaviorSection
+            dividerLine
+            menuBarPreferencesSection
+        }
+    }
 
+    private var topGeneralSection: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            generalBasicsSection
             permissionsSection
         }
     }
@@ -1321,7 +2180,7 @@ struct SettingsView: View {
                     "",
                     isOn: multiUsageBinding
                 )
-                .toggleStyle(FigmaSwitchToggleStyle())
+                .toggleStyle(.switch)
                 .labelsHidden()
                 .allowsHitTesting(false)
 
@@ -1358,13 +2217,13 @@ struct SettingsView: View {
 
                 Spacer(minLength: 0)
             }
-            .frame(width: 410, height: 24, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: 24, alignment: .leading)
 
             statusBarDisplayStylePreview
                 .padding(.leading, 60)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .frame(width: 410, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var statusBarAppearanceModeSection: some View {
@@ -1379,74 +2238,44 @@ struct SettingsView: View {
 
                 Spacer(minLength: 0)
             }
-            .frame(width: 410, height: 24, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: 24, alignment: .leading)
         }
-        .frame(width: 410, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var statusBarAppearanceModeSegmentControl: some View {
-        HStack(spacing: 0) {
-            statusBarAppearanceModeSegmentButton(mode: .followWallpaper, title: settingsStatusBarAppearanceFollowWallpaper)
-            statusBarAppearanceModeSegmentButton(mode: .dark, title: settingsStatusBarAppearanceDark)
-            statusBarAppearanceModeSegmentButton(mode: .light, title: settingsStatusBarAppearanceLight)
+        Picker("", selection: Binding(
+            get: { viewModel.statusBarAppearanceMode.id },
+            set: { newValue in
+                if let mode = StatusBarAppearanceMode.allCases.first(where: { $0.id == newValue }) {
+                    viewModel.setStatusBarAppearanceMode(mode)
+                }
+            }
+        )) {
+            Text(settingsStatusBarAppearanceFollowWallpaper).tag(StatusBarAppearanceMode.followWallpaper.id)
+            Text(settingsStatusBarAppearanceDark).tag(StatusBarAppearanceMode.dark.id)
+            Text(settingsStatusBarAppearanceLight).tag(StatusBarAppearanceMode.light.id)
         }
-        .padding(1)
+        .pickerStyle(.segmented)
+        .controlSize(.small)
         .frame(width: 240, height: 24)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.white.opacity(0.15))
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-    }
-
-    private func statusBarAppearanceModeSegmentButton(mode: StatusBarAppearanceMode, title: String) -> some View {
-        let isSelected = viewModel.statusBarAppearanceMode == mode
-        return Button {
-            viewModel.setStatusBarAppearanceMode(mode)
-        } label: {
-            Text(title)
-                .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
-                .foregroundStyle(isSelected ? Color.black : Color.white.opacity(0.80))
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(isSelected ? Color.white.opacity(0.80) : Color.clear)
-                )
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 
     private var statusBarDisplayStyleSegmentControl: some View {
-        HStack(spacing: 0) {
-            statusBarDisplayStyleSegmentButton(style: .iconPercent, title: settingsStatusBarStyleIconPercent)
-            statusBarDisplayStyleSegmentButton(style: .barNamePercent, title: settingsStatusBarStyleBarNamePercent)
+        Picker("", selection: Binding(
+            get: { viewModel.statusBarDisplayStyle.id },
+            set: { newValue in
+                if let style = StatusBarDisplayStyle.allCases.first(where: { $0.id == newValue }) {
+                    viewModel.setStatusBarDisplayStyle(style)
+                }
+            }
+        )) {
+            Text(settingsStatusBarStyleIconPercent).tag(StatusBarDisplayStyle.iconPercent.id)
+            Text(settingsStatusBarStyleBarNamePercent).tag(StatusBarDisplayStyle.barNamePercent.id)
         }
-        .padding(1)
+        .pickerStyle(.segmented)
+        .controlSize(.small)
         .frame(width: 180, height: 24)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.white.opacity(0.15))
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-    }
-
-    private func statusBarDisplayStyleSegmentButton(style: StatusBarDisplayStyle, title: String) -> some View {
-        let isSelected = viewModel.statusBarDisplayStyle == style
-        return Button {
-            viewModel.setStatusBarDisplayStyle(style)
-        } label: {
-            Text(title)
-                .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
-                .foregroundStyle(isSelected ? Color.black : Color.white.opacity(0.80))
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(isSelected ? Color.white.opacity(0.80) : Color.clear)
-                )
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 
     @ViewBuilder
@@ -1553,81 +2382,81 @@ struct SettingsView: View {
     private var permissionsSection: some View {
         // 权限相关三大块：授权卡片 / 本地扫描 / 重置数据。
         VStack(alignment: .leading, spacing: 24) {
-            VStack(alignment: .leading, spacing: 24) {
-                dividerLine
+            permissionAccessSection
+            dividerLine
+            localDataManagementSection
+        }
+    }
 
-                HStack(spacing: 16) {
-                    permissionStatusTile(
-                        title: viewModel.text(.permissionNotificationsTitle),
-                        hint: viewModel.text(.permissionNotificationsHint),
-                        statusText: notificationPermissionStatusText,
-                        statusColor: notificationPermissionStatusColor,
-                        buttonTitle: notificationActionTitle,
-                        buttonMutedStyle: viewModel.hasNotificationPermission
-                    ) {
-                        handlePermissionAction(.notifications)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
-                    .frame(height: permissionTileHeight > 0 ? permissionTileHeight : nil, alignment: .topLeading)
-
-                    permissionStatusTile(
-                        title: viewModel.text(.permissionKeychainTitle),
-                        hint: viewModel.text(.permissionKeychainHint),
-                        statusText: keychainPermissionStatusText,
-                        statusColor: keychainPermissionStatusColor,
-                        buttonTitle: keychainActionTitle,
-                        buttonMutedStyle: viewModel.secureStorageReady
-                    ) {
-                        handlePermissionAction(.keychain)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
-                    .frame(height: permissionTileHeight > 0 ? permissionTileHeight : nil, alignment: .topLeading)
-
-                    permissionStatusTile(
-                        title: viewModel.text(.permissionFullDiskTitle),
-                        hint: viewModel.text(.permissionFullDiskHint),
-                        statusText: fullDiskPermissionStatusText,
-                        statusColor: fullDiskPermissionStatusColor,
-                        buttonTitle: fullDiskActionTitle,
-                        buttonMutedStyle: viewModel.fullDiskAccessGranted
-                    ) {
-                        handlePermissionAction(.fullDisk)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .topLeading)
-                    .frame(height: permissionTileHeight > 0 ? permissionTileHeight : nil, alignment: .topLeading)
+    private var permissionAccessSection: some View {
+        VStack(alignment: .leading, spacing: 24) {
+            HStack(spacing: 16) {
+                permissionStatusTile(
+                    title: viewModel.text(.permissionNotificationsTitle),
+                    hint: viewModel.text(.permissionNotificationsHint),
+                    statusText: notificationPermissionStatusText,
+                    statusColor: notificationPermissionStatusColor,
+                    buttonTitle: notificationActionTitle,
+                    buttonMutedStyle: viewModel.hasNotificationPermission
+                ) {
+                    handlePermissionAction(.notifications)
                 }
-                .frame(maxWidth: .infinity)
-                .onPreferenceChange(PermissionTileHeightPreferenceKey.self) { newHeight in
-                    // 同步三张权限卡片到统一最大高度。
-                    if abs(permissionTileHeight - newHeight) > 0.5 {
-                        permissionTileHeight = newHeight
-                    }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .frame(height: permissionTileHeight > 0 ? permissionTileHeight : nil, alignment: .topLeading)
+
+                permissionStatusTile(
+                    title: viewModel.text(.permissionKeychainTitle),
+                    hint: viewModel.text(.permissionKeychainHint),
+                    statusText: keychainPermissionStatusText,
+                    statusColor: keychainPermissionStatusColor,
+                    buttonTitle: keychainActionTitle,
+                    buttonMutedStyle: viewModel.secureStorageReady
+                ) {
+                    handlePermissionAction(.keychain)
                 }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .frame(height: permissionTileHeight > 0 ? permissionTileHeight : nil, alignment: .topLeading)
+
+                permissionStatusTile(
+                    title: viewModel.text(.permissionFullDiskTitle),
+                    hint: viewModel.text(.permissionFullDiskHint),
+                    statusText: fullDiskPermissionStatusText,
+                    statusColor: fullDiskPermissionStatusColor,
+                    buttonTitle: fullDiskActionTitle,
+                    buttonMutedStyle: viewModel.fullDiskAccessGranted
+                ) {
+                    handlePermissionAction(.fullDisk)
+                }
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+                .frame(height: permissionTileHeight > 0 ? permissionTileHeight : nil, alignment: .topLeading)
             }
-
-            localDiscoverySection
-
-            VStack(alignment: .leading, spacing: 24) {
-                dividerLine
-
-                resetDataActionRow
+            .frame(maxWidth: .infinity)
+            .onPreferenceChange(PermissionTileHeightPreferenceKey.self) { newHeight in
+                // 同步三张权限卡片到统一最大高度。
+                if abs(permissionTileHeight - newHeight) > 0.5 {
+                    permissionTileHeight = newHeight
+                }
             }
         }
     }
 
-    private var localDiscoverySection: some View {
+    private var localDataManagementSection: some View {
         VStack(alignment: .leading, spacing: 24) {
+            localDiscoverySection
             dividerLine
+            resetDataActionRow
+        }
+    }
 
-            VStack(alignment: .leading, spacing: localDiscoveryItemSpacing) {
-                localDiscoveryHeaderRow
+    private var localDiscoverySection: some View {
+        VStack(alignment: .leading, spacing: localDiscoveryItemSpacing) {
+            localDiscoveryHeaderRow
 
-                if let autoDiscoveryResultText {
-                    localDiscoveryResultRow(autoDiscoveryResultText)
-                }
-
-                localDiscoveryPrivacyBanner
+            if let autoDiscoveryResultText {
+                localDiscoveryResultRow(autoDiscoveryResultText)
             }
+
+            localDiscoveryPrivacyBanner
         }
     }
 
@@ -1752,7 +2581,7 @@ struct SettingsView: View {
         .padding(16)
         .background(
             RoundedRectangle(cornerRadius: cardCornerRadius, style: .continuous)
-                .fill(Color.clear)
+                .fill(settingsSectionFillColor)
         )
         .overlay(
             // 权限卡边框颜色：white_30。
@@ -1809,40 +2638,20 @@ struct SettingsView: View {
     }
 
     private var languageSegmentControl: some View {
-        // 中英文切换分段控件整体外观（背景、尺寸、圆角）。
-        HStack(spacing: 0) {
-            languageSegmentButton(label: viewModel.text(.chinese), value: .zhHans)
-            Rectangle()
-                // 中间竖分隔线。
-                .fill(Color.white.opacity(0.55))
-                .frame(width: 1, height: 14)
-            languageSegmentButton(label: viewModel.text(.english), value: .en)
+        Picker("", selection: Binding(
+            get: { viewModel.language.id },
+            set: { newValue in
+                if let language = AppLanguage.allCases.first(where: { $0.id == newValue }) {
+                    viewModel.setLanguage(language)
+                }
+            }
+        )) {
+            Text(viewModel.text(.chinese)).tag(AppLanguage.zhHans.id)
+            Text(viewModel.text(.english)).tag(AppLanguage.en.id)
         }
+        .pickerStyle(.segmented)
+        .controlSize(.small)
         .frame(width: 140, height: 24)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.white.opacity(0.15))
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-    }
-
-    private func languageSegmentButton(label: String, value: AppLanguage) -> some View {
-        let isSelected = viewModel.language == value
-        return Button {
-            viewModel.setLanguage(value)
-        } label: {
-            Text(label)
-                // 分段项字重、颜色与选中态背景。
-                .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
-                .foregroundStyle(isSelected ? Color.black : Color.white.opacity(0.80))
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(isSelected ? Color.white.opacity(0.8) : Color.clear)
-                )
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
     }
 
     private func settingsCapsuleButton(
@@ -1854,7 +2663,6 @@ struct SettingsView: View {
         borderOpacity: Double = 0.55,
         action: @escaping () -> Void
     ) -> some View {
-        // 设置页统一胶囊按钮（开始扫描/取消授权/重置所有数据等）。
         Button {
             if dismissInputFocus {
                 dismissEditingFocus()
@@ -1863,20 +2671,10 @@ struct SettingsView: View {
         } label: {
             Text(title)
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle((destructive ? Color(hex: 0xD05757) : Color.white).opacity(destructive ? 1 : (disabled ? min(textOpacity, 0.45) : textOpacity)))
-                .padding(.horizontal, 10)
-                .frame(height: 24)
-                .background(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(Color.clear)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .stroke((destructive ? Color(hex: 0xD05757) : Color.white).opacity(destructive ? 1 : (disabled ? min(borderOpacity, 0.35) : borderOpacity)), lineWidth: 1)
-                )
-                .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.bordered)
+        .controlSize(.small)
+        .tint(destructive ? Color(hex: 0xD05757) : settingsAccentBlue)
         .disabled(disabled)
     }
 
@@ -2188,7 +2986,7 @@ struct SettingsView: View {
                 get: { isEnabled },
                 set: { setRelayPresetEnabled($0, preset: preset) }
             ))
-            .toggleStyle(SettingsModelCheckboxToggleStyle())
+            .toggleStyle(.checkbox)
             .labelsHidden()
 
             if let provider {
@@ -2307,7 +3105,7 @@ struct SettingsView: View {
                     .foregroundStyle(settingsTitleColor)
 
                 Toggle("", isOn: enabledBinding)
-                .toggleStyle(FigmaSwitchToggleStyle())
+                .toggleStyle(.switch)
                 .labelsHidden()
                 .allowsHitTesting(false)
 
@@ -2435,7 +3233,7 @@ struct SettingsView: View {
                 .frame(width: labelWidth, alignment: .leading)
 
             Toggle("", isOn: isOn)
-                .toggleStyle(FigmaSwitchToggleStyle())
+                .toggleStyle(.switch)
                 .labelsHidden()
                 .allowsHitTesting(false)
 
@@ -2519,10 +3317,6 @@ struct SettingsView: View {
                     .padding(.top, 12)
             }
 
-            if shouldShowOfficialLocalTrendCard(for: provider) {
-                officialLocalTrendSection(provider: provider, snapshot: snapshot)
-                    .padding(.top, 24)
-            }
         }
     }
 
@@ -2561,74 +3355,22 @@ struct SettingsView: View {
     }
 
     private func officialThresholdStepper(_ provider: ProviderDescriptor) -> some View {
-        HStack(spacing: 0) {
-            TextField(
-                "",
-                text: Binding(
-                    get: {
-                        officialThresholdInputs[provider.id]
-                            ?? formattedOfficialThresholdValue(provider.threshold.lowRemaining)
-                    },
-                    set: { officialThresholdInputs[provider.id] = $0 }
-                ),
-                prompt: settingsInputPrompt("0.00")
-            )
-            .textFieldStyle(.plain)
-            .font(.system(size: 12, weight: .regular))
-            .monospacedDigit()
-            .foregroundStyle(settingsBodyColor)
-            .multilineTextAlignment(.leading)
-            .padding(.horizontal, 10)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
-            .focused($focusedThresholdProviderID, equals: provider.id)
-            .onSubmit {
-                applyOfficialThresholdInput(provider)
-            }
-
-            Rectangle()
-                .fill(Color.white.opacity(0.16))
-                .frame(width: 1)
-
-            VStack(spacing: 0) {
-                Button {
-                    let next = min(100, provider.threshold.lowRemaining + 1)
-                    setOfficialThresholdValue(next, providerID: provider.id)
-                } label: {
-                    Image(systemName: "chevron.up")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(Color.white.opacity(0.80))
-                        .frame(width: 32, height: 12)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-
-                Rectangle()
-                    .fill(Color.white.opacity(0.16))
-                    .frame(height: 1)
-
-                Button {
-                    let next = max(0, provider.threshold.lowRemaining - 1)
-                    setOfficialThresholdValue(next, providerID: provider.id)
-                } label: {
-                    Image(systemName: "chevron.down")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(Color.white.opacity(0.80))
-                        .frame(width: 32, height: 11)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-            }
-            .frame(width: 32)
+        Stepper(
+            value: Binding(
+                get: { provider.threshold.lowRemaining },
+                set: { setOfficialThresholdValue($0, providerID: provider.id) }
+            ),
+            in: 0...100,
+            step: 1
+        ) {
+            Text(formattedOfficialThresholdValue(provider.threshold.lowRemaining))
+                .font(.system(size: 12, weight: .regular))
+                .monospacedDigit()
+                .foregroundStyle(settingsBodyColor)
+                .frame(width: 48, alignment: .trailing)
         }
-        .frame(width: 90, height: 24)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(settingsInputFillColor)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .stroke(Color.black.opacity(0.08), lineWidth: 1)
-        )
+        .controlSize(.small)
+        .frame(width: 118, height: 24)
     }
 
     private func localOfficialAccountSectionTitle(for provider: ProviderDescriptor) -> String {
@@ -3150,7 +3892,12 @@ struct SettingsView: View {
     }
 
     @ViewBuilder
-    private func officialLocalTrendSection(provider: ProviderDescriptor, snapshot: UsageSnapshot?) -> some View {
+    private func officialLocalTrendSection(
+        provider: ProviderDescriptor,
+        snapshot: UsageSnapshot?,
+        showsDivider: Bool = true,
+        title: String? = nil
+    ) -> some View {
         let scope = localUsageTrendScope(for: provider)
         let accountOptions = localUsageTrendAccountOptions(for: provider, snapshot: snapshot)
         let selectedAccountKey = localUsageTrendSelectedAccountKey(
@@ -3193,10 +3940,12 @@ struct SettingsView: View {
         let displaySummary = hasTrendData ? summary : nil
 
         VStack(alignment: .leading, spacing: 0) {
-            dividerLine
+            if showsDivider {
+                dividerLine
+            }
 
             VStack(alignment: .leading, spacing: 0) {
-                Text(viewModel.localizedText("使用趋势", "Usage Trend"))
+                Text(title ?? viewModel.localizedText("使用趋势", "Usage Trend"))
                     .font(.system(size: 12, weight: .semibold))
                     .foregroundStyle(settingsBodyColor)
 
@@ -3227,7 +3976,7 @@ struct SettingsView: View {
                 }
                 .padding(.top, 16)
             }
-            .padding(.top, 24)
+            .padding(.top, showsDivider ? 24 : 0)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .onAppear {
@@ -3309,50 +4058,20 @@ struct SettingsView: View {
     }
 
     private func localUsageTrendScopeSegmentControl(provider: ProviderDescriptor) -> some View {
-        let current = localUsageTrendScope(for: provider)
-        return HStack(spacing: 0) {
-            localUsageTrendScopeButton(
-                title: viewModel.localizedText("全量", "All"),
-                isSelected: current == .allAccounts
-            ) {
-                localUsageTrendScopeBinding(for: provider).wrappedValue = .allAccounts
+        Picker("", selection: Binding(
+            get: { localUsageTrendScope(for: provider).id },
+            set: { newValue in
+                if let scope = LocalUsageTrendScope.allCases.first(where: { $0.id == newValue }) {
+                    localUsageTrendScopeBinding(for: provider).wrappedValue = scope
+                }
             }
-
-            Rectangle()
-                .fill(Color.white.opacity(0.55))
-                .frame(width: 1, height: 14)
-
-            localUsageTrendScopeButton(
-                title: viewModel.localizedText("按账号", "By Account"),
-                isSelected: current == .currentAccount
-            ) {
-                localUsageTrendScopeBinding(for: provider).wrappedValue = .currentAccount
-            }
+        )) {
+            Text(viewModel.localizedText("全量", "All")).tag(LocalUsageTrendScope.allAccounts.id)
+            Text(viewModel.localizedText("按账号", "By Account")).tag(LocalUsageTrendScope.currentAccount.id)
         }
+        .pickerStyle(.segmented)
+        .controlSize(.small)
         .frame(height: 24)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.white.opacity(0.15))
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-    }
-
-    private func localUsageTrendScopeButton(
-        title: String,
-        isSelected: Bool,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Text(title)
-                .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
-                .foregroundStyle(isSelected ? Color.black : Color.white.opacity(0.80))
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(isSelected ? Color.white.opacity(0.80) : Color.clear)
-                )
-        }
-        .buttonStyle(.plain)
     }
 
     private func localUsageTrendEmptyHintText(for provider: ProviderDescriptor) -> String {
@@ -5010,45 +5729,21 @@ struct SettingsView: View {
         options: [Option],
         label: @escaping (Option) -> String
     ) -> some View where Option.ID == String {
-        HStack(spacing: 0) {
-            ForEach(options, id: \.id) { option in
-                officialSegmentButton(
-                    title: label(option),
-                    isSelected: selection.wrappedValue == option
-                ) {
+        Picker("", selection: Binding(
+            get: { selection.wrappedValue.id },
+            set: { newValue in
+                if let option = options.first(where: { $0.id == newValue }) {
                     selection.wrappedValue = option
                 }
             }
+        )) {
+            ForEach(options, id: \.id) { option in
+                Text(label(option)).tag(option.id)
+            }
         }
-        .padding(1)
+        .pickerStyle(.segmented)
+        .controlSize(.small)
         .frame(width: 214, height: 24)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.white.opacity(0.15))
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
-    }
-
-    private func officialSegmentButton(
-        title: String,
-        isSelected: Bool,
-        action: @escaping () -> Void
-    ) -> some View {
-        Button(action: action) {
-            Text(title)
-                .font(.system(size: 12, weight: isSelected ? .semibold : .regular))
-                .foregroundStyle(isSelected ? Color.black : Color.white.opacity(0.80))
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(isSelected ? Color.white.opacity(0.80) : Color.clear)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
-                                .stroke(isSelected ? Color.white.opacity(0.16) : Color.clear, lineWidth: 1)
-                        )
-                )
-        }
-        .buttonStyle(.plain)
     }
 
     private var officialShowEmailTitle: String {
@@ -5902,22 +6597,10 @@ struct SettingsView: View {
         Button(action: action) {
             Text(title)
                 .font(.system(size: 10, weight: .semibold))
-                .foregroundStyle((destructive ? Color(hex: 0xD05757) : Color.white.opacity(disabled ? 0.45 : 0.80)))
-                .padding(.horizontal, 10)
-                .frame(height: 22)
-                .background(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .fill(Color.clear)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
-                        .stroke(
-                            destructive ? Color(hex: 0xD05757) : Color.white.opacity(disabled ? 0.35 : 0.55),
-                            lineWidth: 1
-                        )
-                )
         }
-        .buttonStyle(.plain)
+        .buttonStyle(.bordered)
+        .controlSize(.mini)
+        .tint(destructive ? Color(hex: 0xD05757) : settingsAccentBlue)
         .disabled(disabled)
     }
 
@@ -6698,7 +7381,7 @@ struct SettingsView: View {
             viewModel.resetLocalAppData()
             seedInputsFromConfig()
             syncSelection()
-            selectedSettingsTab = .general
+            selectedSettingsTab = .overview
             permissionResultMessage[PermissionPrompt.resetLocalData.id] = viewModel.text(.resetLocalDataDone)
             permissionResultIsError[PermissionPrompt.resetLocalData.id] = false
         case .none:
@@ -7128,7 +7811,7 @@ struct SettingsView: View {
                             .foregroundStyle(settingsBodyColor)
                             .frame(width: thirdPartyConfigLabelWidth, alignment: .leading)
                         Toggle("", isOn: tokenChannelBinding)
-                            .toggleStyle(FigmaSwitchToggleStyle())
+                            .toggleStyle(.switch)
                             .labelsHidden()
                             .allowsHitTesting(false)
                         Spacer(minLength: 0)
@@ -7149,7 +7832,7 @@ struct SettingsView: View {
                             .foregroundStyle(settingsBodyColor)
                             .frame(width: thirdPartyConfigLabelWidth, alignment: .leading)
                         Toggle("", isOn: accountChannelBinding)
-                            .toggleStyle(FigmaSwitchToggleStyle())
+                            .toggleStyle(.switch)
                             .labelsHidden()
                             .allowsHitTesting(false)
                         Spacer(minLength: 0)
@@ -8436,62 +9119,8 @@ struct SettingsView: View {
         vm.setLanguage(.zhHans)
         return vm
     }())
-    .frame(width: 960, height: 670)
+    .frame(width: 1416, height: 912)
     .preferredColorScheme(.dark)
-}
-
-private struct FigmaSwitchToggleStyle: ToggleStyle {
-    var onTrackOpacity: Double = 0.80
-    var offTrackOpacity: Double = 0.15
-
-    func makeBody(configuration: Configuration) -> some View {
-        Button {
-            withAnimation(.easeInOut(duration: 0.12)) {
-                configuration.isOn.toggle()
-            }
-        } label: {
-            ZStack(alignment: configuration.isOn ? .trailing : .leading) {
-                RoundedRectangle(cornerRadius: 100, style: .continuous)
-                    // 开关轨道：选中/未选中透明度在这里改。
-                    .fill(Color.white.opacity(configuration.isOn ? onTrackOpacity : offTrackOpacity))
-                    .frame(width: 54, height: 24)
-
-                RoundedRectangle(cornerRadius: 100, style: .continuous)
-                    // 开关滑块：尺寸、颜色、阴影在这里改。
-                    .fill(Color.white)
-                    .frame(width: 32, height: 20)
-                    .shadow(color: Color.black.opacity(0.10), radius: 4, x: 0, y: 0)
-                    .shadow(color: Color.black.opacity(0.05), radius: 1, x: 0, y: 0)
-                    .padding(.horizontal, 2)
-            }
-            .frame(width: 64, height: 28, alignment: .center)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
-}
-
-private struct SettingsModelCheckboxToggleStyle: ToggleStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        Button {
-            configuration.isOn.toggle()
-        } label: {
-            ZStack {
-                RoundedRectangle(cornerRadius: 3, style: .continuous)
-                    .fill(configuration.isOn ? Color.white.opacity(0.80) : Color.white.opacity(0.25))
-                    .frame(width: 12, height: 12)
-
-                if configuration.isOn {
-                    Image(systemName: "checkmark")
-                        .font(.system(size: 8, weight: .semibold))
-                        .foregroundStyle(Color.black)
-                }
-            }
-            .frame(width: 20, height: 20, alignment: .center)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-    }
 }
 
 private struct DialogSmoothRoundedRectangle: InsettableShape {

--- a/Sources/AIPlanMonitor/UI/SettingsWindowAppearanceResolver.swift
+++ b/Sources/AIPlanMonitor/UI/SettingsWindowAppearanceResolver.swift
@@ -1,0 +1,46 @@
+import AppKit
+
+enum SettingsWindowAppearanceResolver {
+    static func usesLightAppearance(
+        mode: StatusBarAppearanceMode,
+        wallpaperLuminance: Double?
+    ) -> Bool {
+        switch mode {
+        case .dark:
+            return false
+        case .light:
+            return true
+        case .followWallpaper:
+            guard let wallpaperLuminance else { return false }
+            return wallpaperLuminance >= StatusBarAppearanceResolver.wallpaperLuminanceThreshold
+        }
+    }
+
+    static func wallpaperLuminance(for screen: NSScreen?) -> Double? {
+        guard
+            let screen = screen ?? NSScreen.main,
+            let wallpaperURL = NSWorkspace.shared.desktopImageURL(for: screen),
+            let image = NSImage(contentsOf: wallpaperURL)
+        else {
+            return nil
+        }
+
+        return StatusBarAppearanceResolver.wallpaperTopStripLuminance(from: image)
+    }
+
+    static func appearanceName(usesLightAppearance: Bool) -> NSAppearance.Name {
+        usesLightAppearance ? .aqua : .darkAqua
+    }
+
+    static func backgroundColor(usesLightAppearance: Bool) -> NSColor {
+        usesLightAppearance
+            ? NSColor(red: 243.0 / 255.0, green: 244.0 / 255.0, blue: 246.0 / 255.0, alpha: 1)
+            : NSColor(red: 35.0 / 255.0, green: 35.0 / 255.0, blue: 35.0 / 255.0, alpha: 1)
+    }
+
+    @MainActor
+    static func apply(to window: NSWindow, usesLightAppearance: Bool) {
+        window.appearance = NSAppearance(named: appearanceName(usesLightAppearance: usesLightAppearance))
+        window.backgroundColor = backgroundColor(usesLightAppearance: usesLightAppearance)
+    }
+}


### PR DESCRIPTION
## 概要

重构 macOS 设置窗口，改为更清晰、可拖拽调整大小的设置工作台，并修复浅色/深色外观在整个设置页中的显示一致性问题。

## 主要变更

- 将设置页重构为左侧菜单 + 右侧详情的布局，拆分为概览、常规、菜单栏、权限、本地数据、官方服务、自定义接口等模块。
- 将“外观模式”从“菜单栏”移动到“常规”，并让它作用于整个设置窗口。
- 新增设置窗口外观解析逻辑，支持深色、浅色、跟随壁纸三种模式。
- 设置窗口打开时会让应用显示在程序坞，并支持用户自定义拖拽调整窗口大小。
- 将官方服务的使用趋势集中展示到“概览”页，并且只显示已启用的官方服务。
- 简化顶部操作区，仅保留“刷新全部”并放到右上角。
- 在左侧底部版本区域增加“检查更新”，并在最近刷新下方增加 GitHub 跳转入口。
- 修复浅色模式下服务图标、多账号选择器/弹层、额度条、趋势图、菜单栏预览卡片不可见或对比度不足的问题。

