### PR TITLE
fix: support ~/.kimi-code/ credential and session paths for Kimi CLI

### DIFF
--- a/Sources/OhMyUsage/Providers/KimiOfficialProvider.swift
+++ b/Sources/OhMyUsage/Providers/KimiOfficialProvider.swift
@@ -130,6 +130,7 @@ final class KimiOfficialProvider: UsageProvider, @unchecked Sendable {
     private func resolveCredentialPaths() -> [String] {
         let home = homeDirectory()
         let explicit = [
+            "\(home)/.kimi-code/credentials/kimi-code.json",
             "\(home)/.kimi/credentials/kimi-code.json",
             "\(home)/.config/kimi/credentials/kimi-code.json",
             "\(home)/Library/Application Support/kimi/credentials/kimi-code.json",
@@ -139,9 +140,8 @@ final class KimiOfficialProvider: UsageProvider, @unchecked Sendable {
         ]
 
         var discovered: [String] = []
-        if let enumerator = FileManager.default.enumerator(
-            atPath: "\(home)/.kimi/credentials"
-        ) {
+        for scanDir in ["\(home)/.kimi-code/credentials", "\(home)/.kimi/credentials"] {
+            guard let enumerator = FileManager.default.enumerator(atPath: scanDir) else { continue }
             for case let item as String in enumerator {
                 let lower = item.lowercased()
                 guard lower.hasSuffix(".json"),
@@ -149,7 +149,7 @@ final class KimiOfficialProvider: UsageProvider, @unchecked Sendable {
                       lower.contains("code") else {
                     continue
                 }
-                discovered.append("\(home)/.kimi/credentials/\(item)")
+                discovered.append("\(scanDir)/\(item)")
             }
         }
 

--- a/Sources/OhMyUsage/Services/KimiLocalUsageService.swift
+++ b/Sources/OhMyUsage/Services/KimiLocalUsageService.swift
@@ -71,7 +71,13 @@ final class KimiLocalUsageService {
         if let defaultSessionsRootPath {
             return defaultSessionsRootPath
         }
-        return "\(NSHomeDirectory())/.kimi/sessions"
+        let home = NSHomeDirectory()
+        let kimiCodeSessions = "\(home)/.kimi-code/sessions"
+        var isDir: ObjCBool = false
+        if FileManager.default.fileExists(atPath: kimiCodeSessions, isDirectory: &isDir), isDir.boolValue {
+            return kimiCodeSessions
+        }
+        return "\(home)/.kimi/sessions"
     }
 
     private func scanSessionEvents(


### PR DESCRIPTION
## Problem

The Kimi CLI (`kimi-code`) stores its OAuth credentials at `~/.kimi-code/credentials/kimi-code.json` and session data at `~/.kimi-code/sessions/`. However, `KimiOfficialProvider` only searches `~/.kimi/` paths, so credential discovery fails for users with the Kimi CLI installed.

This results in:
- `ProviderError.missingCredential` thrown by `KimiOfficialProvider.loadCredentials()`
- Fallback to `KimiProvider` (web/cookie mode), which also fails if the user has no browser cookies for `kimi.com`
- Kimi verification appears broken even though valid OAuth credentials exist on disk

## Root Cause

The Kimi CLI uses `~/.kimi-code/` as its home directory (note the `-code` suffix), but `resolveCredentialPaths()` only checks:
- `~/.kimi/credentials/kimi-code.json`
- `~/.config/kimi/credentials/kimi-code.json`
- `~/Library/Application Support/kimi/credentials/kimi-code.json`
- `~/Library/Application Support/Kimi/credentials/kimi-code.json`
- `~/.kimi/oauth/kimi-code.json`
- `~/.kimi/credentials/oauth/kimi-code.json`

The actual credential file at `~/.kimi-code/credentials/kimi-code.json` (with valid `access_token`, `refresh_token`, `expires_at` fields) is never found.

## Fix

### `KimiOfficialProvider.swift`
- Added `~/.kimi-code/credentials/kimi-code.json` to the explicit path list (first priority)
- Extended the directory scan to also enumerate `~/.kimi-code/credentials/` for JSON files matching the `kimi` + `code` naming pattern

### `KimiLocalUsageService.swift`
- Added fallback check for `~/.kimi-code/sessions/` before defaulting to `~/.kimi/sessions/` (the Kimi CLI also stores session data under `~/.kimi-code/`)

## Testing

Verified on a machine with Kimi CLI installed:
- Credential file exists at `~/.kimi-code/credentials/kimi-code.json` with valid OAuth fields
- After this fix (or a `~/.kimi → ~/.kimi-code` symlink workaround), `KimiOfficialProvider` successfully discovers credentials and fetches usage from `https://api.kimi.com/coding/v1/usages`

## Notes

The Kimi CLI may have migrated from `~/.kimi/` to `~/.kimi-code/` as its home directory in a recent update. This change adds the new path while keeping all existing paths for backward compatibility.